### PR TITLE
Introduce rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 js/
 node_modules/
 npm-debug.log
+dist/

--- a/README.md
+++ b/README.md
@@ -12,14 +12,18 @@ Install dependencies with npm (or alternatively install them manually):
 
     $ npm install
 
-To compile the TypeScript sources to JavaScript (ES2015), run `tsc` in the main
-directory.
+To compile the TypeScript sources to a single JavaScript (ES2015) file, run
+`rollup` in the main directory.
 
-    $ node_modules/.bin/tsc
+    $ npm run rollup
 
-You can also watch the files for changes and recompile automatically:
+The resulting file will be located in `dist/saltyrtc.js`.
 
-    $ node_modules/.bin/tsc -w
+Due to a bug (https://github.com/rollup/rollup-plugin-typescript/issues/43),
+rollup does not currently output non-fatal errors from TypeScript. To see
+those, simply issue `npm run tsc` in your main directory.
+
+    $ npm run tsc
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ To compile the TypeScript sources to a single JavaScript (ES2015) file, run
 
 The resulting file will be located in `dist/saltyrtc.js`.
 
+You can also watch the source code for changes and recompile automatically:
+
+    $ npm run watch
+
 Due to a bug (https://github.com/rollup/rollup-plugin-typescript/issues/43),
 rollup does not currently output non-fatal errors from TypeScript. To see
-those, simply issue `npm run tsc` in your main directory.
+those, simply issue `npm run validate` in your main directory.
 
-    $ npm run tsc
+    $ npm run validate
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "description": "SaltyRTC JavaScript implementation",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "tsc": "tsc",
+    "rollup": "rollup -c"
   },
   "repository": {
     "type": "git",
@@ -23,6 +25,8 @@
   },
   "homepage": "https://github.com/saltyrtc/saltyrtc-client-js#readme",
   "devDependencies": {
+    "rollup": "^0.26",
+    "rollup-plugin-typescript": "^0.7.5",
     "typescript": "^1.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "SaltyRTC JavaScript implementation",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "tsc": "tsc",
-    "rollup": "rollup -c"
+    "validate": "tsc -w",
+    "rollup": "rollup -c",
+    "watch": "watch \"npm run rollup\" saltyrtc/"
   },
   "repository": {
     "type": "git",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "rollup": "^0.26",
     "rollup-plugin-typescript": "^0.7.5",
-    "typescript": "^1.8.0"
+    "typescript": "^1.8.0",
+    "watch": "^0.18.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,42 @@
+import typescript from 'rollup-plugin-typescript';
+
+export default {
+    entry: 'saltyrtc/main.ts',
+    dest: 'dist/saltyrtc.js',
+    sourceMap: true,
+    treeshake: true,
+    plugins: [
+        typescript({
+            tsconfig: false,
+            target: 'ES2015',
+            removeComments: true
+        })
+    ],
+    banner: "/**\n" +
+            " * SaltyRTC JavaScript implementation\n" +
+            " * https://github.com/saltyrtc/saltyrtc-client-js\n" +
+            " *\n" +
+            " * Copyright (C) 2016 Threema GmbH / SaltyRTC Contributors\n" +
+            " *\n" +
+            " * This software may be modified and distributed under the terms\n" +
+            " * of the MIT license:\n" +
+            " * \n" +
+            " * Permission is hereby granted, free of charge, to any person obtaining a copy\n" +
+            " * of this software and associated documentation files (the \"Software\"), to deal\n" +
+            " * in the Software without restriction, including without limitation the rights\n" +
+            " * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n" +
+            " * copies of the Software, and to permit persons to whom the Software is\n" +
+            " * furnished to do so, subject to the following conditions:\n" +
+            " * \n" +
+            " * The above copyright notice and this permission notice shall be included in all\n" +
+            " * copies or substantial portions of the Software.\n" +
+            " * \n" +
+            " * THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n" +
+            " * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n" +
+            " * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n" +
+            " * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n" +
+            " * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n" +
+            " * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n" +
+            " * SOFTWARE.\n" +
+            " */"
+}

--- a/saltyrtc/main.ts
+++ b/saltyrtc/main.ts
@@ -1,0 +1,9 @@
+/**
+ * Entry point for the library. The full public API should be re-exported here.
+ *
+ * Copyright (C) 2016 Threema GmbH / SaltyRTC Contributors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the `LICENSE.md` file for details.
+ */
+export { Client } from "./client";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "compilerOptions": {
         "target": "ES2015",
-        "removeComments": true,
-        "outDir": "js",
-        "sourceMap": true
+        "noEmit": true
     }
 }


### PR DESCRIPTION
Rollup (http://rollupjs.org/) is a module bundler that converts projects using the ES2015 module system to a single JavaScript file.

By using a typescript plugin, we can compile from ts to js in the same step. Correct sourcemaps are also generated. Additionally, a tree-shaking algorithm removes unused code from the output file.

Note that due to a bug (https://github.com/rollup/rollup-plugin-typescript/issues/43), rollup does not currently output non-fatal errors from TypeScript. To see those, simply issue `npm run tsc` in your main directory. (That will invoke tsc directly with the noEmit option.)