### PR TITLE
Remove PeerConnection

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,0 +1,54 @@
+/**
+ * Usage example.
+ */
+
+/// <reference path='saltyrtc/types/RTCPeerConnection.d.ts' />
+
+import { SaltyRTC, KeyStore, PeerConnection, DataChannel } from "saltyrtc/main";
+
+let ks = new KeyStore();
+let sc = new SaltyRTC(null, ks, null, new DataChannel(null, ks, new PeerConnection(null)));
+
+async function initiatorFlow(pc: RTCPeerConnection, sc: SaltyRTC) {
+    let offer = await pc.createOffer()
+    await pc.setLocalDescription(offer);
+    sc.onReceiveAnswer = (answer) => {
+        pc.setRemoteDescription(answer)
+            .catch(error => console.error('Could not set remote description', error));
+    };
+    sc.sendOffer(offer);
+}
+
+async function main(): Promise<void/*SecureDataChannel*/> {
+
+    // Create new peer connection
+    let pc = new RTCPeerConnection({
+        iceServers: [{
+            urls: ['turn:example.com'],
+            username: 'user',
+            credential: 'pass',
+        }],
+    });
+
+//    // SaltyRTC handshake
+//    sc.connect(pc);
+//
+//    // Do initiator flow
+//    await initiatorFlow(pc, sc).then(
+//        value => console.debug('Initiator flow successful'),
+//        error => console.error('Initiator flow failed', error));
+//
+//    // Start handover in background
+//    let handover = sc.handover(pc).then(
+//        value => console.info('Handover successful'),
+//        error => console.error('Handover failed', error));
+//
+//    // Wrap insecure data channel
+//    let dc = sc.wrapDataChannel(pc.createDataChannel("seriously-secure"));
+//
+//    // Return data channel instance
+//    await handover;
+//    return dc;
+}
+
+main();

--- a/saltyrtc/chunkifier.ts
+++ b/saltyrtc/chunkifier.ts
@@ -1,0 +1,128 @@
+/**
+ * Convert an array to chunks.
+ *
+ * This is required for now as a workaround because the Chrome implementation
+ * does not currently support sending messages larger than 16 KiB:
+ * https://webrtc.org/web-apis/chrome/
+ */
+export class Chunkifier {
+    private _array: Uint8Array;
+    private _chunkSize: number;
+    private _chunks: Uint8Array[] = null;
+
+    constructor(array: Uint8Array, chunkSize: number) {
+        this._array = array;
+        this._chunkSize = chunkSize;
+    }
+
+    get chunks(): Uint8Array[] {
+        return this._getChunks();
+    }
+
+    private _offset(index: number): number {
+        return index * (this._chunkSize - 1);
+    }
+
+    private _hasNext(index: number): boolean {
+        return this._offset(index) < this._array.length;
+    }
+
+    private _getChunks(): Uint8Array[] {
+        // Generate chunks on demand
+        if (this._chunks === null) {
+            this._chunks = [];
+            let index = 0;
+            while (this._hasNext(index)) {
+                // More chunks?
+                let offset = this._offset(index);
+                let length = Math.min(this._chunkSize, this._array.length + 1 - offset);
+                let buffer = new ArrayBuffer(length);
+                let view = new DataView(buffer);
+
+                // Put more chunks indicator into buffer
+                if (this._hasNext(index + 1)) {
+                    view.setUint8(0, 1);
+                } else {
+                    view.setUint8(0, 0);
+                }
+
+                // Add array slice to buffer
+                let array = new Uint8Array(buffer);
+                let end = Math.min(this._offset(index + 1), this._array.length);
+                let chunk = this._array.slice(offset, end);
+                array.set(chunk, 1);
+
+                // Add array to list of chunks
+                this._chunks[index] = array;
+                index += 1;
+            }
+        }
+        return this._chunks;
+    }
+}
+
+
+/**
+ * Combine chunks into a single array.
+ *
+ * See `Chunkifier` doc comment for more information.
+ */
+export class Unchunkifier {
+    private _events;
+    private _chunks: Uint8Array[];
+    private _length: number = 0;
+
+    constructor(events) {
+        this._events = events;
+        this._reset();
+    }
+
+    /**
+     * Add a chunk.
+     */
+    add(array: Uint8Array): void {
+        if (array.length == 0) {
+            return;
+        }
+        let view = new DataView(array.buffer);
+
+        // Add to list
+        this._chunks.push(array);
+        this._length += (array.length - 1);
+
+        // More chunks?
+        let moreChunks = view.getUint8(0);
+        if (moreChunks == 0) {
+            this._done();
+        } else if (moreChunks != 1) {
+            throw 'Invalid chunk received: ' + moreChunks;
+        }
+    }
+
+    /**
+     * Reset the unchunkifier data.
+     */
+    private _reset(): void {
+        this._chunks = [];
+        this._length = 0;
+    }
+
+    private _done() {
+        let message = this._merge();
+        this._reset();
+        this._events.onCompletedMessage(message);
+    }
+
+    private _merge() {
+        let array = new Uint8Array(this._length);
+
+        // Add all chunks apart from the first byte
+        let offset = 0;
+        for (var chunk of this._chunks) {
+            array.set(chunk.slice(1), offset);
+            offset += chunk.length - 1;
+        }
+
+        return array;
+    }
+}

--- a/saltyrtc/client.ts
+++ b/saltyrtc/client.ts
@@ -77,15 +77,16 @@ export class SaltyRTC {
     constructor($rootScope: angular.IRootScopeService,
                 keyStore: KeyStore,
                 session: Session,
-                signaling: Signaling,
                 peerConnection: PeerConnection,
                 dataChannel: DataChannel) {
         this.$rootScope = $rootScope;
         this.keyStore = keyStore;
         this.session = session;
-        this.signaling = signaling;
         this.peerConnection = peerConnection;
         this.dataChannel = dataChannel;
+
+        // Initialize signaling class
+        this.signaling = new Signaling(this, $rootScope, keyStore, session);
 
         // Setup state event handler
         // Note: This handler should only handle states that can't be handled by the

--- a/saltyrtc/client.ts
+++ b/saltyrtc/client.ts
@@ -247,6 +247,16 @@ export class SaltyRTC {
         });
     }
 
+    /**
+     * Send an ICE candidate through the signalling channel.
+     *
+     * TODO: Make sure candidates are buffered for 10ms, according to the
+     * SaltyRTC spec.
+     */
+    public sendCandidate(candidate: RTCIceCandidate) {
+        this.signaling.sendCandidate(candidate);
+    }
+
     private _reset(peerConnection: boolean, signaling: boolean): void {
         // Cancel timers
         this._cancelConnectTimer();

--- a/saltyrtc/client.ts
+++ b/saltyrtc/client.ts
@@ -271,7 +271,7 @@ export class SaltyRTC {
         }
     }
 
-    _connect(): void {
+    private _connect(): void {
         // Create peer connection and connect to signaling server
         this.session.new();
         console.info('Connecting');
@@ -281,7 +281,7 @@ export class SaltyRTC {
         this.signaling.connect(u8aToHex(this.keyStore.keyPair.publicKey));
     }
 
-    _reconnect(peerConnection: boolean, signaling: boolean, silent: boolean = false): void {
+    private _reconnect(peerConnection: boolean, signaling: boolean, silent: boolean = false): void {
         // Reset instances
         this._reset(peerConnection, signaling);
 
@@ -318,14 +318,14 @@ export class SaltyRTC {
         }
     }
 
-    _updateClientState(state): void {
+    private _updateClientState(state): void {
         this.state = state;
 
         // Broadcast
         this.$rootScope.$broadcast('webclient:state', this.state);
     }
 
-    _updateState(name, value): void {
+    private _updateState(name, value): void {
         // Update state type and value
         this.states[name].type = this._getStateType(name, value);
         this.states[name].value = value;
@@ -386,7 +386,7 @@ export class SaltyRTC {
         return 'unknown';
     }
 
-    _startConnectTimer(): void {
+    private _startConnectTimer(): void {
         this._connectTimer = setTimeout(() => {
             // Notify that connecting timed out
             console.warn('Data Channel connect timeout');
@@ -395,14 +395,14 @@ export class SaltyRTC {
         }, SaltyRTC.CONNECT_TIMEOUT);
     }
 
-    _cancelConnectTimer(): void {
+    private _cancelConnectTimer(): void {
         if (this._connectTimer !== null) {
             clearTimeout(this._connectTimer);
             this._connectTimer = null;
         }
     }
 
-    _startDisconnectTimer(): void {
+    private _startDisconnectTimer(): void {
         this._disconnectTimer = setTimeout(() => {
             // Notify that the connection has been lost
             console.warn('Peer Connection lost');
@@ -411,7 +411,7 @@ export class SaltyRTC {
         }, SaltyRTC.DISCONNECT_TIMEOUT);
     }
 
-    _cancelDisconnectTimer(): void {
+    private _cancelDisconnectTimer(): void {
         if (this._disconnectTimer !== null) {
             clearTimeout(this._disconnectTimer);
             this._disconnectTimer = null;

--- a/saltyrtc/client.ts
+++ b/saltyrtc/client.ts
@@ -251,6 +251,13 @@ export class SaltyRTC {
         this.signaling.sendOffer(offerSdp);
     }
 
+    /**
+     * Receive an answer through the signalling channel.
+     */
+    public onReceiveAnswer(answerSdp: RTCSessionDescription) {
+        console.debug('SaltyRTC: Received answer');
+    }
+
     private _reset(peerConnection: boolean, signaling: boolean): void {
         // Cancel timers
         this._cancelConnectTimer();

--- a/saltyrtc/client.ts
+++ b/saltyrtc/client.ts
@@ -182,10 +182,6 @@ export class SaltyRTC {
             console.debug('Signaling state changed to:', state);
             this._updateState('signaling', state);
         });
-        this.$rootScope.$on('pc:state', (_, state) => {
-            console.debug('Peer Connection state changed to:', state);
-            this._updateState('pc', state);
-        });
         this.$rootScope.$on('dc:state', (_, state) => {
             console.debug('Data Channel state changed to:', state);
             this._updateState('dc', state);
@@ -195,10 +191,6 @@ export class SaltyRTC {
         this.$rootScope.$on('signaling:error', (_, state, error) => {
             console.error('Signaling error state:', state, ', Message:', error);
             this._handleError('signaling', state, error);
-        });
-        this.$rootScope.$on('pc:error', (_, state, error) => {
-            console.error('Peer Connection error state:', state, ', Message:', error);
-            this._handleError('pc', state, error);
         });
         this.$rootScope.$on('dc:error', (_, state, error) => {
             console.error('Data Channel error state:', state, ', Message:', error);
@@ -240,11 +232,6 @@ export class SaltyRTC {
         this.$rootScope.$on('signaling:candidate', (_, candidate) => {
             this.peerConnection.receiveCandidate(candidate);
         });
-
-        // Listen for peer connection events and delegate them
-        this.$rootScope.$on('pc:candidate', (_, candidate) => {
-            this.signaling.sendCandidate(candidate);
-        });
     }
 
     /**
@@ -255,6 +242,13 @@ export class SaltyRTC {
      */
     public sendCandidate(candidate: RTCIceCandidate) {
         this.signaling.sendCandidate(candidate);
+    }
+
+    /**
+     * Send an offer through the signalling channel.
+     */
+    public sendOffer(offerSdp: RTCSessionDescription) {
+        this.signaling.sendOffer(offerSdp);
     }
 
     private _reset(peerConnection: boolean, signaling: boolean): void {

--- a/saltyrtc/client.ts
+++ b/saltyrtc/client.ts
@@ -25,7 +25,7 @@ interface State {
     value: string,
 }
 
-export class Client {
+export class SaltyRTC {
     static CONNECT_TIMEOUT: number = 85000;
     static DISCONNECT_TIMEOUT: number = 35000;
 
@@ -334,21 +334,21 @@ export class Client {
         let weight = 0;
         for (let key in this.states) {
             let state = this.states[key];
-            weight += Client.STATE_WEIGHT[state.type];
+            weight += SaltyRTC.STATE_WEIGHT[state.type];
         }
 
         // Data channel open and PC at most unstable: Force warning if danger
-        if (weight >= Client.STATE_WEIGHT.danger
+        if (weight >= SaltyRTC.STATE_WEIGHT.danger
             && this.states['dc'].type == 'success'
             && this.states['pc'].type != 'danger') {
-            weight = Client.STATE_WEIGHT.warning;
+            weight = SaltyRTC.STATE_WEIGHT.warning;
         }
 
         // Calculate state type
         let state;
-        if (weight < Client.STATE_WEIGHT.warning) {
+        if (weight < SaltyRTC.STATE_WEIGHT.warning) {
             state = {type: 'success', value: 'connected'};
-        } else if (weight < Client.STATE_WEIGHT.danger) {
+        } else if (weight < SaltyRTC.STATE_WEIGHT.danger) {
             state = {type: 'warning', value: 'unstable'};
         } else {
             state = {type: 'danger', value: 'disconnected'};
@@ -375,7 +375,7 @@ export class Client {
     }
 
     private _getStateType(name: string, value: string): string {
-        let rules = Client.STATE_RULES[name];
+        let rules = SaltyRTC.STATE_RULES[name];
         // Check if the value is in one of the keys
         for (let key in rules) {
             let states = rules[key];
@@ -392,7 +392,7 @@ export class Client {
             console.warn('Data Channel connect timeout');
             this._updateClientState({type: 'danger', value: 'timeout'});
             this._reconnect(true, false);
-        }, Client.CONNECT_TIMEOUT);
+        }, SaltyRTC.CONNECT_TIMEOUT);
     }
 
     _cancelConnectTimer(): void {
@@ -408,7 +408,7 @@ export class Client {
             console.warn('Peer Connection lost');
             this._updateClientState({type: 'danger', value: 'lost'});
             this._reconnect(true, false);
-        }, Client.DISCONNECT_TIMEOUT);
+        }, SaltyRTC.DISCONNECT_TIMEOUT);
     }
 
     _cancelDisconnectTimer(): void {

--- a/saltyrtc/datachannel.ts
+++ b/saltyrtc/datachannel.ts
@@ -11,6 +11,7 @@
 import { KeyStore, Box } from "./keystore";
 import { PeerConnection } from "./peerconnection";
 import { randomString } from "./utils";
+import { Chunkifier, Unchunkifier } from "./chunkifier";
 
 /**
  * A message that is sent through the data channel.
@@ -18,122 +19,6 @@ import { randomString } from "./utils";
 interface DCMessage {
     type: "message" | "heartbeat" | "heartbeat-ack",
     data: string | Object,
-}
-
-class Chunkifier {
-    private _array: Uint8Array;
-    private _chunkSize: number;
-    private _chunks: Uint8Array[] = null;
-
-    constructor(array: Uint8Array, chunkSize: number) {
-        this._array = array;
-        this._chunkSize = chunkSize;
-    }
-
-    get chunks(): Uint8Array[] {
-        return this._getChunks();
-    }
-
-    private _offset(index: number): number {
-        return index * (this._chunkSize - 1);
-    }
-
-    private _hasNext(index: number): boolean {
-        return this._offset(index) < this._array.length;
-    }
-
-    private _getChunks(): Uint8Array[] {
-        // Generate chunks on demand
-        if (this._chunks === null) {
-            this._chunks = [];
-            let index = 0;
-            while (this._hasNext(index)) {
-                // More chunks?
-                let offset = this._offset(index);
-                let length = Math.min(this._chunkSize, this._array.length + 1 - offset);
-                let buffer = new ArrayBuffer(length);
-                let view = new DataView(buffer);
-
-                // Put more chunks indicator into buffer
-                if (this._hasNext(index + 1)) {
-                    view.setUint8(0, 1);
-                } else {
-                    view.setUint8(0, 0);
-                }
-
-                // Add array slice to buffer
-                let array = new Uint8Array(buffer);
-                let end = Math.min(this._offset(index + 1), this._array.length);
-                let chunk = this._array.slice(offset, end);
-                array.set(chunk, 1);
-
-                // Add array to list of chunks
-                this._chunks[index] = array;
-                index += 1;
-            }
-        }
-        return this._chunks;
-    }
-}
-
-class Unchunkifier {
-    private _events;
-    private _chunks: Uint8Array[];
-    private _length: number = 0;
-
-    constructor(events) {
-        this._events = events;
-        this._reset();
-    }
-
-    /**
-     * Add a chunk.
-     */
-    add(array: Uint8Array): void {
-        if (array.length == 0) {
-            return;
-        }
-        let view = new DataView(array.buffer);
-
-        // Add to list
-        this._chunks.push(array);
-        this._length += (array.length - 1);
-
-        // More chunks?
-        let moreChunks = view.getUint8(0);
-        if (moreChunks == 0) {
-            this._done();
-        } else if (moreChunks != 1) {
-            throw 'Invalid chunk received: ' + moreChunks;
-        }
-    }
-
-    /**
-     * Reset the unchunkifier data.
-     */
-    private _reset(): void {
-        this._chunks = [];
-        this._length = 0;
-    }
-
-    private _done() {
-        let message = this._merge();
-        this._reset();
-        this._events.onCompletedMessage(message);
-    }
-
-    private _merge() {
-        let array = new Uint8Array(this._length);
-
-        // Add all chunks apart from the first byte
-        let offset = 0;
-        for (var chunk of this._chunks) {
-            array.set(chunk.slice(1), offset);
-            offset += chunk.length - 1;
-        }
-
-        return array;
-    }
 }
 
 class DataChannelEvents {

--- a/saltyrtc/keystore.ts
+++ b/saltyrtc/keystore.ts
@@ -64,10 +64,8 @@ interface IKeyPair {
 
 export class KeyStore {
     // Public key of the recipient
-    // TODO: Does this need to be public?
     public otherKey = null;
     // The NaCl key pair
-    // TODO: Does this need to be public?
     public keyPair: IKeyPair;
 
     constructor() {

--- a/saltyrtc/main.ts
+++ b/saltyrtc/main.ts
@@ -6,5 +6,5 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the `LICENSE.md` file for details.
  */
-export { Client } from "./client";
+export { SaltyRTC } from "./client";
 export { PeerConnection } from "./peerconnection";

--- a/saltyrtc/main.ts
+++ b/saltyrtc/main.ts
@@ -8,3 +8,5 @@
  */
 export { SaltyRTC } from "./client";
 export { PeerConnection } from "./peerconnection";
+export { KeyStore, Box } from "./keystore";
+export { DataChannel } from "./datachannel";

--- a/saltyrtc/peerconnection.ts
+++ b/saltyrtc/peerconnection.ts
@@ -181,7 +181,7 @@ export class PeerConnection {
         });
     }
 
-    receiveAnswer(descriptionInit: RTCSessionDescriptionInit) {
+    public receiveAnswer(descriptionInit: RTCSessionDescriptionInit) {
         console.info('Received answer');
         let description = new RTCSessionDescription(descriptionInit);
         this.pc.setRemoteDescription(

--- a/saltyrtc/signaling.ts
+++ b/saltyrtc/signaling.ts
@@ -11,6 +11,7 @@
 
 import { Session } from "./session";
 import { KeyStore, Box } from "./keystore";
+import { SaltyRTC } from "./client";
 
 interface CachedSignalingMessage {
     message: SignalingMessage,
@@ -83,6 +84,7 @@ export class Signaling {
     static CONNECT_MAX_RETRIES: number = 10;
     static CONNECT_RETRY_INTERVAL: number = 10000;
 
+    private saltyrtc: SaltyRTC;
     private $rootScope: angular.IRootScopeService;
     private keyStore: KeyStore;
     private session: Session;
@@ -95,9 +97,11 @@ export class Signaling {
     private _events: SignalingEvents = null;
     private ws: WebSocket;
 
-    constructor($rootScope: angular.IRootScopeService,
+    constructor(saltyrtc: SaltyRTC,
+                $rootScope: angular.IRootScopeService,
                 keyStore: KeyStore,
                 session: Session) {
+        this.saltyrtc = saltyrtc;
         this.$rootScope = $rootScope;
         this.keyStore = keyStore;
         this.session = session;
@@ -237,11 +241,6 @@ export class Signaling {
         });
     }
 
-    public receiveAnswer(answer): void {
-        console.debug('Broadcasting answer');
-        this.$rootScope.$broadcast('signaling:answer', answer);
-    }
-
     sendCandidate(candidate): void {
         console.debug('Sending candidate');
         this._send({
@@ -354,7 +353,7 @@ export class Signaling {
         // Dispatch message
         switch (message.type) {
             case 'answer':
-                this.receiveAnswer(message.data);
+                this.saltyrtc.onReceiveAnswer(message.data);
                 break;
             case 'candidate':
                 this.receiveCandidate(message.data);

--- a/saltyrtc/signaling.ts
+++ b/saltyrtc/signaling.ts
@@ -7,6 +7,7 @@
 
 /// <reference path="types/angular.d.ts" />
 /// <reference path="types/websocket.d.ts" />
+/// <reference path='types/RTCPeerConnection.d.ts' />
 
 import { Session } from "./session";
 import { KeyStore, Box } from "./keystore";
@@ -227,12 +228,12 @@ export class Signaling {
         this.$rootScope.$broadcast('signaling:key', key);
     }
 
-    sendOffer(offer): void { // TODO: type
+    public sendOffer(offerSdp: RTCSessionDescription): void {
         console.debug('Sending offer');
         this._send({
             type: 'offer',
             session: this.session.id,
-            data: offer,
+            data: offerSdp,
         });
     }
 

--- a/saltyrtc/signaling.ts
+++ b/saltyrtc/signaling.ts
@@ -237,7 +237,7 @@ export class Signaling {
         });
     }
 
-    receiveAnswer(answer): void {
+    public receiveAnswer(answer): void {
         console.debug('Broadcasting answer');
         this.$rootScope.$broadcast('signaling:answer', answer);
     }
@@ -308,7 +308,7 @@ export class Signaling {
         }
     }
 
-    _receiveText(data): void {
+    _receiveText(data: string): void {
         let message = JSON.parse(data);
         console.debug('Received text signaling message:', message);
 
@@ -328,7 +328,7 @@ export class Signaling {
         }
     }
 
-    _receiveBinary(data): void {
+    _receiveBinary(data: ArrayBuffer): void {
         // Convert to Uint8Array
         let box: Box = this.keyStore.boxFromArray(new Uint8Array(data));
 

--- a/saltyrtc/types/RTCPeerConnection.d.ts
+++ b/saltyrtc/types/RTCPeerConnection.d.ts
@@ -3,15 +3,7 @@
 // Definitions by: Ken Smith <https://github.com/smithkl42/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 //
-// Definitions taken from http://dev.w3.org/2011/webrtc/editor/webrtc.html
-//
-// For example code see:
-//   https://code.google.com/p/webrtc/source/browse/stable/samples/js/apprtc/js/main.js
-//
-// For a generic implementation see that deals with browser differences, see:
-//   https://code.google.com/p/webrtc/source/browse/stable/samples/js/base/adapter.js
-//
-// Copied on 2016-05-04.
+// W3 Spec: https://www.w3.org/TR/webrtc/#idl-def-RTCIceServer
 
 /// <reference path='MediaStream.d.ts' />
 
@@ -22,17 +14,46 @@
 // TODO(2): get Typescript to have union types as WebRtc uses them.
 // https://typescript.codeplex.com/workitem/1364
 
-interface RTCConfiguration {
-  iceServers: RTCIceServer[];
+// https://www.w3.org/TR/webrtc/#idl-def-RTCIceTransportPolicy
+type RTCIceTransportPolicy = 'public' | 'relay' | 'all';
+
+// https://www.w3.org/TR/webrtc/#idl-def-RTCBundlePolicy
+type RTCBundlePolicy = 'balanced' | 'max-compat' | 'max-bundle';
+
+// https://www.w3.org/TR/webrtc/#idl-def-RTCRtcpMuxPolicy
+type RTCRtcpMuxPolicy = 'negotiate' | 'require';
+
+// https://www.w3.org/TR/webrtc/#idl-def-RTCCertificate
+interface RTCCertificate {
+    expires: number;
 }
+
+// https://www.w3.org/TR/webrtc/#idl-def-RTCConfiguration
+// https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#RTCConfiguration_dictionary
+interface RTCConfiguration {
+  iceServers           ?: RTCIceServer[];        // optional according to mozilla docs
+  iceTransportPolicy   ?: RTCIceTransportPolicy; // default = 'all'
+  bundlePolicy         ?: RTCBundlePolicy;       // default = 'balanced'
+  rtcpMuxPolicy        ?: RTCRtcpMuxPolicy;      // default = 'require'
+  peerIdentity         ?: string;                // default = null
+  certificates         ?: RTCCertificate[];      // default is auto-generated
+  iceCandidatePoolSize ?: number;                // default = 0
+}
+
 declare var RTCConfiguration: {
   prototype: RTCConfiguration;
   new (): RTCConfiguration;
 };
 
+// https://www.w3.org/TR/webrtc/#idl-def-RTCIceCredentialType
+type RTCIceCredentialType = 'password' | 'token';
+
+// https://www.w3.org/TR/webrtc/#idl-def-RTCIceServer
 interface RTCIceServer {
-  urls: string;
+  urls: string | string[];
+  username?: string;
   credential?: string;
+  credentialType?: RTCIceCredentialType; // default = 'password'
 }
 declare var RTCIceServer: {
   prototype: RTCIceServer;
@@ -44,7 +65,7 @@ interface mozRTCPeerConnection extends RTCPeerConnection {
 }
 declare var mozRTCPeerConnection: {
   prototype: mozRTCPeerConnection;
-  new (settings: RTCPeerConnectionConfig,
+  new (settings?: RTCConfiguration,
        constraints?:RTCMediaConstraints): mozRTCPeerConnection;
 };
 // webkit (Chrome) specific prefixes.
@@ -52,7 +73,7 @@ interface webkitRTCPeerConnection extends RTCPeerConnection {
 }
 declare var webkitRTCPeerConnection: {
   prototype: webkitRTCPeerConnection;
-  new (settings: RTCPeerConnectionConfig,
+  new (settings?: RTCConfiguration,
        constraints?:RTCMediaConstraints): webkitRTCPeerConnection;
 };
 
@@ -245,24 +266,40 @@ interface RTCStatsCallback {
   (report: RTCStatsReport): void;
 }
 
+interface RTCOfferAnswerOptions {
+    voiceActivityDetection ?: boolean; // default = true
+}
+
+interface RTCOfferOptions extends RTCOfferAnswerOptions {
+    iceRestart ?: boolean; // default = false
+}
+
+interface RTCAnswerOptions extends RTCOfferAnswerOptions { }
+
 interface RTCPeerConnection {
+
+  createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescription>;
   createOffer(successCallback: RTCSessionDescriptionCallback,
               failureCallback?: RTCPeerConnectionErrorCallback,
-              constraints?: RTCMediaConstraints): void;
+              constraints?: RTCMediaConstraints): void; // Deprecated
+  createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescription>;
   createAnswer(successCallback: RTCSessionDescriptionCallback,
                failureCallback?: RTCPeerConnectionErrorCallback,
-               constraints?: RTCMediaConstraints): void;
+               constraints?: RTCMediaConstraints): void; // Deprecated
+  setLocalDescription(description: RTCSessionDescription | RTCSessionDescriptionInit): Promise<void>;
   setLocalDescription(description: RTCSessionDescription,
                       successCallback?: RTCVoidCallback,
-                      failureCallback?: RTCPeerConnectionErrorCallback): void;
-  localDescription: RTCSessionDescription;
+                      failureCallback?: RTCPeerConnectionErrorCallback): void; // Deprecated
+  setRemoteDescription(description: RTCSessionDescription | RTCSessionDescriptionInit): Promise<void>;
   setRemoteDescription(description: RTCSessionDescription,
                         successCallback?: RTCVoidCallback,
                         failureCallback?: RTCPeerConnectionErrorCallback): void;
+  localDescription: RTCSessionDescription;
   remoteDescription: RTCSessionDescription;
   signalingState: string; // RTCSignalingState; see TODO(1)
   updateIce(configuration?: RTCConfiguration,
             constraints?: RTCMediaConstraints): void;
+  addIceCandidate(candidate: RTCIceCandidate): Promise<void>;
   addIceCandidate(candidate:RTCIceCandidate,
                   successCallback:() => void,
                   failureCallback:RTCPeerConnectionErrorCallback): void;
@@ -286,8 +323,10 @@ interface RTCPeerConnection {
   onicecandidate: (event: RTCIceCandidateEvent) => void;
   onidentityresult: (event: Event) => void;
   onsignalingstatechange: (event: Event) => void;
-  getStats: (successCallback: RTCStatsCallback,
-             failureCallback: RTCPeerConnectionErrorCallback) => void;
+  getStats(selector: MediaStreamTrack): Promise<RTCStatsReport>;
+  getStats(selector: MediaStreamTrack, // nullable
+           successCallback: RTCStatsCallback,
+           failureCallback: RTCPeerConnectionErrorCallback): void;
 }
 declare var RTCPeerConnection: {
   prototype: RTCPeerConnection;
@@ -296,7 +335,7 @@ declare var RTCPeerConnection: {
 };
 
 interface RTCIceCandidate {
-  candidate?: string;
+  candidate: string;
   sdpMid?: string;
   sdpMLineIndex?: number;
 }
@@ -306,7 +345,7 @@ declare var RTCIceCandidate: {
 };
 
 interface webkitRTCIceCandidate extends RTCIceCandidate {
-  candidate?: string;
+  candidate: string;
   sdpMid?: string;
   sdpMLineIndex?: number;
 }
@@ -316,7 +355,7 @@ declare var webkitRTCIceCandidate: {
 };
 
 interface mozRTCIceCandidate extends RTCIceCandidate {
-  candidate?: string;
+  candidate: string;
   sdpMid?: string;
   sdpMLineIndex?: number;
 }
@@ -327,8 +366,8 @@ declare var mozRTCIceCandidate: {
 
 interface RTCIceCandidateInit {
   candidate: string;
-  sdpMid: string;
-  sdpMLineIndex: number;
+  sdpMid?: string;
+  sdpMLineIndex?: number;
 }
 declare var RTCIceCandidateInit:{
   prototype: RTCIceCandidateInit;


### PR DESCRIPTION
I'm working on the removal of the PeerConnection object from the client. Right now some code is commented out, but at least the dependency on the `PeerConnection` class is gone.

I also added an example, based on the call flow at https://gist.github.com/lgrahl/6227024501dee06a29e23d4184658786. Parts of it are commented out because the corresponding methods don't yet exist.

@lgrahl this is still WIP, but in case you see something that should be done differently let me know. I'll merge this on Tuesday when I get back to work :)