### PR TITLE
Change build pipeline to generate ES5 code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 js/
 node_modules/
 npm-debug.log
+build/
 dist/
 docs/
 saltyrtc.crt

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,11 @@ before_script:
   # Rollup tests
   - npm run rollup_tests
 script:
-  - node_modules/.bin/tsc --target ES2015 --noEmit
   - npm test
+  - |
+    mv tsconfig.json tsconfig.ignore
+    node_modules/.bin/tsc --target ES2015 --noEmit
+    mv tsconfig.ignore tsconfig.json
 after_script:
   # Stop SaltyRTC server
   - kill -INT $SALTYRTC_SERVER_PID

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/saltyrtc/saltyrtc-client-js)
 
 This is a [SaltyRTC](https://github.com/saltyrtc/saltyrtc-meta) implementation
-for ECMAScript 2015 written in TypeScript 1.8+.
+for JavaScript (ES5) written in TypeScript 1.8+.
 
 The development is still ongoing, the library is not yet production ready.
 
@@ -57,12 +57,11 @@ Install dependencies with npm (or alternatively install them manually):
 
     $ npm install
 
-To compile the TypeScript sources to a single JavaScript (ES2015) file, run
-`rollup` in the main directory.
+To compile the TypeScript sources to a single minified JavaScript (ES5) file:
 
-    $ npm run rollup
+    $ npm run dist
 
-The resulting file will be located in `dist/saltyrtc.js`.
+The resulting file will be located in `dist/saltyrtc.min.js`.
 
 You can also watch the source code for changes and recompile automatically:
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "karma-chrome-launcher": "^1.0.1",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "^1.0.2",
-    "rollup": "^0.30",
+    "rollup": "^0.33",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-typescript": "^0.7.6",
     "rollup-plugin-uglify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "SaltyRTC JavaScript implementation",
   "scripts": {
     "test": "karma start --single-run --log-level=debug --colors",
-    "validate": "tsc -w",
-    "rollup": "rollup -c",
+    "dist": "tsc && rollup -c",
     "rollup_tests": "rollup -c rollup.testing.js",
-    "watch": "watch \"npm run rollup\" saltyrtc/",
+    "watch": "watch \"npm run dist\" saltyrtc/",
     "watch_tests": "watch \"npm run rollup_tests\" tests/ saltyrtc/"
   },
   "repository": {
@@ -28,15 +27,23 @@
   },
   "homepage": "https://github.com/saltyrtc/saltyrtc-client-js#readme",
   "devDependencies": {
+    "babel-preset-es2015-rollup": "^1.1.1",
     "jasmine-core": "^2.4",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^1.0.1",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "^1.0.2",
-    "rollup": "^0.26",
-    "rollup-plugin-typescript": "^0.7.5",
-    "typescript": "^1.8.0",
+    "rollup": "^0.30",
+    "rollup-plugin-babel": "^2.6.1",
+    "rollup-plugin-typescript": "^0.7.6",
+    "rollup-plugin-uglify": "^1.0.1",
+    "typescript": "^1.8.9",
     "watch": "^0.18.0",
     "webrtc-adapter": "^1.4.0"
+  },
+  "babel": {
+    "presets": [
+      "es2015-rollup"
+    ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,17 +1,19 @@
-import typescript from 'rollup-plugin-typescript';
+import babel from 'rollup-plugin-babel';
+import uglify from 'rollup-plugin-uglify';
 
 export default {
-    entry: 'saltyrtc/main.ts',
-    dest: 'dist/saltyrtc.js',
-    sourceMap: true,
+    entry: 'build/es2015/main.js',
+    dest: 'dist/saltyrtc.min.js',
+    format: 'iife',
+    moduleName: 'saltyrtc',
+    sourceMap: false,
     treeshake: true,
     useStrict: true,
     plugins: [
-        typescript({
-            tsconfig: false,
-            target: 'ES2015',
-            removeComments: true
-        })
+        babel({
+            exclude: 'node_modules/**'
+        }),
+        uglify()
     ],
     banner: "/**\n" +
             " * SaltyRTC JavaScript implementation\n" +

--- a/rollup.testing.js
+++ b/rollup.testing.js
@@ -12,33 +12,5 @@ export default {
             target: 'ES2015',
             removeComments: false
         })
-    ],
-    banner: "/**\n" +
-            " * SaltyRTC JavaScript Tests\n" +
-            " * https://github.com/saltyrtc/saltyrtc-client-js\n" +
-            " *\n" +
-            " * Copyright (C) 2016 Threema GmbH / SaltyRTC Contributors\n" +
-            " *\n" +
-            " * This software may be modified and distributed under the terms\n" +
-            " * of the MIT license:\n" +
-            " * \n" +
-            " * Permission is hereby granted, free of charge, to any person obtaining a copy\n" +
-            " * of this software and associated documentation files (the \"Software\"), to deal\n" +
-            " * in the Software without restriction, including without limitation the rights\n" +
-            " * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n" +
-            " * copies of the Software, and to permit persons to whom the Software is\n" +
-            " * furnished to do so, subject to the following conditions:\n" +
-            " * \n" +
-            " * The above copyright notice and this permission notice shall be included in all\n" +
-            " * copies or substantial portions of the Software.\n" +
-            " * \n" +
-            " * THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n" +
-            " * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n" +
-            " * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n" +
-            " * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n" +
-            " * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n" +
-            " * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n" +
-            " * SOFTWARE.\n" +
-            " */\n" +
-            "'use strict';\n"
+    ]
 }

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -4,9 +4,9 @@ import { sleep } from "./utils";
 import { SaltyRTC } from "../saltyrtc/client";
 import { KeyStore } from "../saltyrtc/keystore";
 
-export default () => { describe('client', () => {
+export default () => { describe('client', function() {
 
-    describe('SaltyRTC', () => {
+    describe('SaltyRTC', function() {
 
         /*it('wrapDataChannel() acts as a proxy', () => {
             let pc = new RTCPeerConnection({iceServers: [{urls: ['stun:stun.services.mozilla.com']}]});
@@ -16,7 +16,7 @@ export default () => { describe('client', () => {
             proxy.send("hello");
         });*/
 
-        describe('events', () => {
+        describe('events', function() {
 
             beforeEach(() => {
                 this.sc = new SaltyRTC(new KeyStore(), 'localhost');

--- a/tests/cookie.spec.ts
+++ b/tests/cookie.spec.ts
@@ -2,9 +2,9 @@
 
 import { Cookie } from "../saltyrtc/cookie";
 
-export default () => { describe('cookie', () => {
+export default () => { describe('cookie', function() {
 
-    describe('Cookie', () => {
+    describe('Cookie', function() {
 
         it('generates a cookie of the correct length', () => {
             let c = new Cookie();

--- a/tests/eventregistry.spec.ts
+++ b/tests/eventregistry.spec.ts
@@ -2,9 +2,9 @@
 
 import { SaltyRTCEvent, EventHandler, EventRegistry } from "../saltyrtc/eventregistry";
 
-export default () => { describe('eventregistry', () => {
+export default () => { describe('eventregistry', function() {
 
-    describe('EventRegistry', () => {
+    describe('EventRegistry', function() {
 
         beforeEach(() => {
             this.registry = new EventRegistry();

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -10,7 +10,7 @@ import { Config } from "./config";
 import { sleep } from "./utils";
 import { SaltyRTC, KeyStore } from "../saltyrtc/main";
 
-export default () => { describe('Integration Tests', () => {
+export default () => { describe('Integration Tests', function() {
 
     beforeEach(() => {
         this.initiator = new SaltyRTC(new KeyStore(),

--- a/tests/keystore.spec.ts
+++ b/tests/keystore.spec.ts
@@ -4,9 +4,9 @@ import { Box, KeyStore, AuthToken } from "../saltyrtc/keystore";
 
 declare var nacl: any; // TODO
 
-export default () => { describe('keystore', () => {
+export default () => { describe('keystore', function() {
 
-    describe('Box', () => {
+    describe('Box', function() {
 
         let nonce = nacl.randomBytes(24);
         let data = nacl.randomBytes(7);
@@ -45,7 +45,7 @@ export default () => { describe('keystore', () => {
 
     });
 
-    describe('KeyStore', () => {
+    describe('KeyStore', function() {
 
         let ks = new KeyStore();
         let nonce = nacl.randomBytes(24);
@@ -94,7 +94,7 @@ export default () => { describe('keystore', () => {
 
     });
 
-    describe('AuthToken', () => {
+    describe('AuthToken', function() {
 
         let at = new AuthToken();
 

--- a/tests/nonce.spec.ts
+++ b/tests/nonce.spec.ts
@@ -3,9 +3,9 @@
 import { DataChannelNonce, SignalingChannelNonce } from "../saltyrtc/nonce";
 import { Cookie } from "../saltyrtc/cookie";
 
-export default () => { describe('nonce', () => {
+export default () => { describe('nonce', function() {
 
-    describe('DataChannelNonce', () => {
+    describe('DataChannelNonce', function() {
 
         beforeEach(() => {
             this.array = new Uint8Array([
@@ -37,7 +37,7 @@ export default () => { describe('nonce', () => {
 
     });
 
-    describe('SignalingChannelNonce', () => {
+    describe('SignalingChannelNonce', function() {
 
         beforeEach(() => {
             this.array = new Uint8Array([

--- a/tests/signaling.spec.ts
+++ b/tests/signaling.spec.ts
@@ -30,9 +30,9 @@ class FakeWebSocket {
     } 
 }
 
-export default () => { describe('signaling', () => {
+export default () => { describe('signaling', function() {
 
-    describe('Signaling', () => {
+    describe('Signaling', function() {
 
         beforeEach(() => {
             this.fakeSaltyRTC = new FakeSaltyRTC() as any as SaltyRTC;

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -2,9 +2,9 @@
 
 import { u8aToHex, hexToU8a, randomString, concat, randomUint32, byteToHex } from "../saltyrtc/utils";
 
-export default () => { describe('utils', () => {
+export default () => { describe('utils', function() {
 
-    describe('hexToU8a / u8aToHex', () => {
+    describe('hexToU8a / u8aToHex', function() {
 
         it('conversion from Uint8Array to hex works', () => {
             let source = new Uint8Array([0x01, 0x10, 0xde, 0xad, 0xbe, 0xef]);
@@ -32,7 +32,7 @@ export default () => { describe('utils', () => {
 
     });
 
-    describe('randomString', () => {
+    describe('randomString', function() {
 
         it('generates a 32 character random string', () => {
             let random1 = randomString();
@@ -44,7 +44,7 @@ export default () => { describe('utils', () => {
 
     });
 
-    describe('concat', () => {
+    describe('concat', function() {
 
         it('does not change a single array', () => {
             let src = Uint8Array.of(1, 2, 3, 4);
@@ -69,7 +69,7 @@ export default () => { describe('utils', () => {
 
     });
 
-    describe('randomUint32', () => {
+    describe('randomUint32', function() {
 
         it('generates a random number between 0 and 2**32', () => {
             let lastNum: number = null;
@@ -84,7 +84,7 @@ export default () => { describe('utils', () => {
 
     });
 
-    describe('byteToHex', () => {
+    describe('byteToHex', function() {
 
         it('converts 0 to 0x00', () => {
             expect(byteToHex(0)).toEqual('0x00');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,15 @@
 {
     "compilerOptions": {
         "target": "ES2015",
-        "noEmit": true
-    }
+        "removeComments": true,
+        "outDir": "build/es2015"
+    },
+    "exclude": [
+        "node_modules",
+        "tests",
+        "build",
+        "dist",
+        "cli",
+        "example.ts"
+    ]
 }


### PR DESCRIPTION
- Code is now transpiled for ES5 using Babel
- Typescript processing is done in a separate step, to allow for things like .d.ts file generation
- An UglifyJS step reduces the file size by more than 50%
- Tests still use the rollup-typescript plugin