### PR TITLE
Fix handling of disconnected messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Possible log types:
 
 ### v0.12.0 (unreleased)
 
-- [changed] Rename `onDisconnected` in task interface to `onPeerDisconnected`
-- [fixed] Only call `onPeerDisconnected` if defined by the task
+- [changed] Disconnected messages are now emitted as events to the user,
+  not as callback to the task (#92)
 - [fixed] Accept server messages during/after peer handshake
 - [fixed] If message nonce has an invalid source, discard it
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -128,6 +128,7 @@ The following events are available:
  - `state-change:<new-state>(void)`: The signaling state change event, filtered by state.
  - `new-responder(responderId)`: A responder has connected. This event is only dispatched for the initiator.
  - `application(data)`: An application message has arrived.
+ - `peer-disconnected(peerId)`: A previously authenticated peer has disconnected from the server.
  - `handover(void)`: The handover to the data channel is done.
  - `signaling-connection-lost(responderId)`: The signaling connection to the specified peer was lost.
  - `connection-closed(closeCode)`: The connection was closed.

--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -144,14 +144,6 @@ declare namespace saltyrtc {
         onPeerHandshakeDone(): void;
 
         /**
-         * This method is called by SaltyRTC when a 'disconnected' message
-         * arrives through the WebSocket.
-         *
-         * @param id The responder ID of the peer that disconnected.
-         */
-        onPeerDisconnected(id: number): void;
-
-        /**
          * This method is called by SaltyRTC when a task related message
          * arrives through the WebSocket.
          *

--- a/src/signaling/common.ts
+++ b/src/signaling/common.ts
@@ -455,7 +455,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
             console.debug(this.logTag, 'Received close');
             this.handleClose(msg as saltyrtc.messages.Close);
         } else if (msg.type === 'disconnected') {
-            console.debug(this.logTag, 'Received disconnected');
+            console.debug(this.logTag, 'Received disconnected message');
             this.handleDisconnected(msg as saltyrtc.messages.Disconnected);
         } else if (msg.type === 'application') {
             console.debug(this.logTag, 'Received application message');
@@ -587,14 +587,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
      * Handle an incoming disconnected message.
      */
     protected handleDisconnected(msg: saltyrtc.messages.Disconnected): void {
-        console.info(this.logTag, 'Received disconnected message. Peer ID:', msg.id);
-
-        // Notify the task
-        if (this.task.onPeerDisconnected !== undefined) {
-            this.task.onPeerDisconnected(msg.id);
-        } else {
-            console.warn(this.logTag, 'Task does not define an onPeerDisconnected method!');
-        }
+        this.client.emit({type: 'peer-disconnected', data: msg.id});
     }
 
     /**


### PR DESCRIPTION
Do not notify the task via callback, instead notify user via
'peer-disconnected' event.