### PR TITLE
Revert const enums

### DIFF
--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -38,15 +38,7 @@ declare namespace saltyrtc {
         type: messages.MessageType;
     }
 
-    const enum SignalingState {
-        New = 'new',
-        WsConnecting = 'ws-connecting',
-        ServerHandshake = 'server-handshake',
-        PeerHandshake = 'peer-handshake',
-        Task = 'task',
-        Closing = 'closing',
-        Closed = 'closed',
-    }
+    type SignalingState = 'new' | 'ws-connecting' | 'server-handshake' | 'peer-handshake' | 'task' | 'closing' | 'closed';
 
     interface HandoverState {
         local: boolean;
@@ -57,10 +49,9 @@ declare namespace saltyrtc {
         reset(): void;
     }
 
-    const enum SignalingRole {
-        Initiator = 'initiator',
-        Responder = 'responder',
-    }
+    type SignalingChannel = 'websocket' | 'datachannel';
+
+    type SignalingRole = 'initiator' | 'responder';
 
     interface SaltyRTCEvent {
         type: string;
@@ -68,9 +59,7 @@ declare namespace saltyrtc {
     }
     type SaltyRTCEventHandler = (event: SaltyRTCEvent) => boolean | void;
 
-    interface TaskData {
-        [index: string]: any;
-    }
+    type TaskData = { [index:string] : any };
 
     interface Signaling {
         handoverState: HandoverState;
@@ -275,10 +264,7 @@ declare namespace saltyrtc {
         theirs: Cookie;
     }
 
-    interface NextCombinedSequence {
-        sequenceNumber: number;
-        overflow: number;
-    }
+    type NextCombinedSequence = { sequenceNumber: number, overflow: number };
 
     interface CombinedSequence {
         next(): NextCombinedSequence;
@@ -293,7 +279,6 @@ declare namespace saltyrtc {
         closeCode: number;
     }
 
-    // tslint:disable-next-line:no-empty-interface
     interface ConnectionError extends Error {
     }
 
@@ -301,39 +286,26 @@ declare namespace saltyrtc {
 
 declare namespace saltyrtc.messages {
 
-    const enum MessageType {
-        ServerHello = 'server-hello',
-        ClientHello = 'client-hello',
-        ClientAuth = 'client-auth',
-        ServerAuth = 'server-auth',
-        NewInitiator = 'new-initiator',
-        NewResponder = 'new-responder',
-        DropResponder = 'drop-responder',
-        SendError = 'send-error',
-        Token = 'token',
-        Key = 'key',
-        Auth = 'auth',
-        Restart = 'restart',
-        Close = 'close',
-        Disconnected = 'disconnected',
-        Applicatiion = 'application',
-    }
+    type MessageType = 'server-hello' | 'client-hello' | 'client-auth'
+                     | 'server-auth' | 'new-initiator' | 'new-responder'
+                     | 'drop-responder' | 'send-error' | 'token' | 'key'
+                     | 'auth' | 'restart' | 'close' | 'disconnected' | 'application';
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#server-hello
     interface ServerHello extends SignalingMessage {
-        type: MessageType.ServerHello;
+        type: 'server-hello';
         key: ArrayBuffer;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#client-hello
     interface ClientHello extends SignalingMessage {
-        type: MessageType.ClientHello;
+        type: 'client-hello';
         key: ArrayBuffer;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#client-auth
     interface ClientAuth extends SignalingMessage {
-        type: MessageType.ClientAuth;
+        type: 'client-auth';
         your_cookie: ArrayBuffer;
         your_key?: ArrayBuffer | null;
         subprotocols: string[];
@@ -342,7 +314,7 @@ declare namespace saltyrtc.messages {
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#server-auth
     interface ServerAuth extends SignalingMessage {
-        type: MessageType.ServerAuth;
+        type: 'server-auth';
         your_cookie: ArrayBuffer;
         signed_keys?: ArrayBuffer;
         initiator_connected?: boolean;
@@ -351,43 +323,43 @@ declare namespace saltyrtc.messages {
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#new-initiator
     interface NewInitiator extends SignalingMessage {
-        type: MessageType.NewInitiator;
+        type: 'new-initiator';
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#new-responder
     interface NewResponder extends SignalingMessage {
-        type: MessageType.NewResponder;
+        type: 'new-responder';
         id: number;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#drop-responder
     interface DropResponder extends SignalingMessage {
-        type: MessageType.DropResponder;
+        type: 'drop-responder';
         id: number;
         reason?: number;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#send-error
     interface SendError extends SignalingMessage {
-        type: MessageType.SendError;
+        type: 'send-error';
         id: ArrayBuffer;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#token-message
     interface Token extends SignalingMessage {
-        type: MessageType.Token;
+        type: 'token';
         key: ArrayBuffer;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#key-message
     interface Key extends SignalingMessage {
-        type: MessageType.Key;
+        type: 'key';
         key: ArrayBuffer;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#auth-message
     interface Auth extends SignalingMessage {
-        type: MessageType.Auth;
+        type: 'auth';
         your_cookie: ArrayBuffer;
         data: { [index:string] : any };
     }
@@ -400,18 +372,18 @@ declare namespace saltyrtc.messages {
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#restart
     interface Restart extends SignalingMessage {
-        type: MessageType.Restart;
+        type: 'restart';
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#close-message
     interface Close extends SignalingMessage {
-        type: MessageType.Close;
+        type: 'close';
         reason: number;
     }
 
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#disconnected-message
     interface Disconnected extends SignalingMessage {
-        type: MessageType.Disconnected;
+        type: 'disconnected';
         id: number;
     }
 

--- a/src/signaling/common.ts
+++ b/src/signaling/common.ts
@@ -43,7 +43,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
     };
 
     // Connection state
-    protected state: saltyrtc.SignalingState = saltyrtc.SignalingState.New;
+    protected state: saltyrtc.SignalingState = 'new';
     public handoverState = new HandoverState();
 
     // Main class
@@ -167,7 +167,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
         const reason = CloseCode.ClosingNormal;
 
         // Update state
-        this.setState(saltyrtc.SignalingState.Closing);
+        this.setState('closing');
 
         // Send close message if necessary
         if (this.state === 'task') {
@@ -188,7 +188,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
         }
 
         // Update state
-        this.setState(saltyrtc.SignalingState.Closed);
+        this.setState('closed');
     }
 
     /**
@@ -214,7 +214,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
         this.ws.addEventListener('message', this.onMessage);
 
         // Store connection on instance
-        this.setState(saltyrtc.SignalingState.WsConnecting);
+        this.setState('ws-connecting');
         console.debug(this.logTag, 'Opening WebSocket connection to', url + path);
     }
 
@@ -223,7 +223,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
      */
     protected onOpen = (ev: Event) => {
         console.info(this.logTag, 'Opened connection');
-        this.setState(saltyrtc.SignalingState.ServerHandshake);
+        this.setState('server-handshake');
     }
 
     /**
@@ -244,7 +244,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
             console.info(this.logTag, 'Closed WebSocket connection due to handover');
         } else {
             console.info(this.logTag, 'Closed WebSocket connection');
-            this.setState(saltyrtc.SignalingState.Closed);
+            this.setState('closed');
             this.client.emit({type: 'connection-closed', data: ev.code});
             const log = (reason: string) => console.error(this.logTag, 'Websocket close reason:', reason);
             switch (ev.code) {
@@ -408,7 +408,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
 
         // Check if we're done yet
         if (this.server.handshakeState as string === 'done') {
-            this.setState(saltyrtc.SignalingState.PeerHandshake);
+            this.setState('peer-handshake');
             console.debug(this.logTag, 'Server handshake done');
             this.initPeerHandshake();
         }
@@ -498,7 +498,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
      */
     protected sendClientAuth(): void {
         const message: saltyrtc.messages.ClientAuth = {
-            type: saltyrtc.messages.MessageType.ClientAuth,
+            type: 'client-auth',
             your_cookie: this.server.cookiePair.theirs.asArrayBuffer(),
             subprotocols: [Signaling.SALTYRTC_SUBPROTOCOL],
             ping_interval: this.pingInterval,
@@ -561,7 +561,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
      */
     public sendClose(reason: number): void {
         const message: saltyrtc.messages.Close = {
-            type: saltyrtc.messages.MessageType.Close,
+            type: 'close',
             reason: reason,
         };
         console.debug(this.logTag, 'Sending close');
@@ -944,7 +944,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
         // Reset
         this.server = new Server();
         this.handoverState.reset();
-        this.setState(saltyrtc.SignalingState.New);
+        this.setState('new');
         if (reason !== undefined) {
             console.debug(this.logTag, 'Connection reset');
         }

--- a/src/signaling/initiator.ts
+++ b/src/signaling/initiator.ts
@@ -32,7 +32,7 @@ export class InitiatorSignaling extends Signaling {
                 tasks: saltyrtc.Task[], pingInterval: number,
                 permanentKey: saltyrtc.KeyStore, responderTrustedKey?: Uint8Array) {
         super(client, host, port, serverKey, tasks, pingInterval, permanentKey, responderTrustedKey);
-        this.role = saltyrtc.SignalingRole.Initiator;
+        this.role = 'initiator';
         if (responderTrustedKey === undefined) {
             this.authToken = new AuthToken();
         }
@@ -284,7 +284,7 @@ export class InitiatorSignaling extends Signaling {
                     this.dropResponders(CloseCode.DroppedByInitiator);
 
                     // Peer handshake done
-                    this.setState(saltyrtc.SignalingState.Task);
+                    this.setState('task');
                     console.info(this.logTag, 'Peer handshake done');
                     this.task.onPeerHandshakeDone();
 
@@ -374,7 +374,7 @@ export class InitiatorSignaling extends Signaling {
      */
     private sendKey(responder: Responder): void {
         const message: saltyrtc.messages.Key = {
-            type: saltyrtc.messages.MessageType.Key,
+            type: 'key',
             key: responder.keyStore.publicKeyBytes.buffer,
         };
         const packet: Uint8Array = this.buildPacket(message, responder);
@@ -398,7 +398,7 @@ export class InitiatorSignaling extends Signaling {
 
         // Send auth
         const message: saltyrtc.messages.InitiatorAuth = {
-            type: saltyrtc.messages.MessageType.Auth,
+            type: 'auth',
             your_cookie: nonce.cookie.asArrayBuffer(),
             task: this.task.getName(),
             data: taskData,
@@ -543,7 +543,7 @@ export class InitiatorSignaling extends Signaling {
      */
     private dropResponder(responderId: number, reason: number) {
         const message: saltyrtc.messages.DropResponder = {
-            type: saltyrtc.messages.MessageType.DropResponder,
+            type: 'drop-responder',
             id: responderId,
             reason: reason,
         };

--- a/src/signaling/responder.ts
+++ b/src/signaling/responder.ts
@@ -28,7 +28,7 @@ export class ResponderSignaling extends Signaling {
                 permanentKey: saltyrtc.KeyStore, initiatorPubKey: Uint8Array, authToken?: saltyrtc.AuthToken) {
         super(client, host, port, serverKey, tasks, pingInterval,
               permanentKey, authToken === undefined ? initiatorPubKey : undefined);
-        this.role = saltyrtc.SignalingRole.Responder;
+        this.role = 'responder';
         this.initiator = new Initiator(initiatorPubKey);
         if (authToken !== undefined) {
             this.authToken = authToken;
@@ -168,7 +168,7 @@ export class ResponderSignaling extends Signaling {
                     this.handleAuth(msg as saltyrtc.messages.InitiatorAuth, nonce);
 
                     // We're connected!
-                    this.setState(saltyrtc.SignalingState.Task);
+                    this.setState('task');
                     console.info(this.logTag, 'Peer handshake done');
 
                     break;
@@ -210,7 +210,7 @@ export class ResponderSignaling extends Signaling {
 
     protected sendClientHello(): void {
         const message: saltyrtc.messages.ClientHello = {
-            type: saltyrtc.messages.MessageType.ClientHello,
+            type: 'client-hello',
             key: this.permanentKey.publicKeyBytes.buffer,
         };
         const packet: Uint8Array = this.buildPacket(message, this.server, false);
@@ -281,7 +281,7 @@ export class ResponderSignaling extends Signaling {
      */
     protected sendToken(): void {
         const message: saltyrtc.messages.Token = {
-            type: saltyrtc.messages.MessageType.Token,
+            type: 'token',
             key: this.permanentKey.publicKeyBytes.buffer,
         };
         const packet: Uint8Array = this.buildPacket(message, this.initiator);
@@ -299,7 +299,7 @@ export class ResponderSignaling extends Signaling {
 
         // Send public key to initiator
         const replyMessage: saltyrtc.messages.Key = {
-            type: saltyrtc.messages.MessageType.Key,
+            type: 'key',
             key: this.sessionKey.publicKeyBytes.buffer,
         };
         const packet: Uint8Array = this.buildPacket(replyMessage, this.initiator);
@@ -334,7 +334,7 @@ export class ResponderSignaling extends Signaling {
 
         // Send auth
         const message: saltyrtc.messages.ResponderAuth = {
-            type: saltyrtc.messages.MessageType.Auth,
+            type: 'auth',
             your_cookie: nonce.cookie.asArrayBuffer(),
             tasks: taskNames,
             data: taskData,


### PR DESCRIPTION
It unfortunately breaks our current rollup workflow: The typescript
const enums are not properly inlined.

This reverts commits b7017d4fcd75ef20800d5a1392582bef52e29d18
and 905491fd814663c2da1c03803620de8440d9b11c.