### PR TITLE
Crypto Performance Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 npm-debug.log
 tests/testsuite.js*
+tests/performance.js*
 apidocs/
 saltyrtc.crt
 saltyrtc.csr

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -14,7 +14,7 @@ To initialize a SaltyRTC client instance, you can use the `SaltyRTCBuilder`.
 let builder = new saltyrtcClient.SaltyRTCBuilder();
 ```
 
-### Connection info
+### Connection Info
 
 Then you need to provide connection info:
 
@@ -26,7 +26,7 @@ builder.connectTo(host, port);
 
 For testing, you can use [our test server](https://saltyrtc.org/pages/getting-started.html).
 
-### Key store
+### Key Store
 
 The client needs to have its own public/private keypair. Create a new keypair
 with the `KeyStore` class:
@@ -36,7 +36,7 @@ const keyStore = new saltyrtcClient.KeyStore();
 builder.withKeyStore(keyStore);
 ```
 
-### Server key pinning
+### Server Key Pinning
 
 If you want to use server key pinning, specify the server public permanent key:
 
@@ -47,7 +47,7 @@ builder.withServerKey(serverPublicPermanentKey);
 
 The public key can either be passed in as `Uint8Array` or as hex-encoded string.
 
-### Websocket ping interval
+### Websocket Ping Interval
 
 Optionally, you can specify a Websocket ping interval in seconds:
 
@@ -55,7 +55,7 @@ Optionally, you can specify a Websocket ping interval in seconds:
 builder.withPingInterval(30);
 ```
 
-### Task configuration
+### Task Configuration
 
 You must initialize SaltyRTC with a task (TODO: Link to tasks documentation)
 that takes over after the handshake is done.
@@ -92,7 +92,7 @@ const client = builder.asResponder();
 Both the initiator public permanent key as well as the initiator auth token can
 be either `Uint8Array` instances or hex-encoded strings.
 
-## Full example
+## Full Example
 
 All methods on the `SaltyRTCBuilder` support chaining. Here's a full example of
 an initiator configuration:
@@ -135,7 +135,7 @@ The following events are available:
  - `connection-closed(closeCode)`: The connection was closed.
  - `connection-error(ErrorEvent)`: A websocket connection error occured.
 
-## Trusted keys
+## Trusted Keys
 
 In order to reconnect to a session using a trusted key, you first need to
 restore your `KeyStore` with the private permanent key originally used to
@@ -155,7 +155,7 @@ builder.withTrustedPeerKey(peerPublicPermanentKey);
 
 The public key can be passed in either as `Uint8Array` or as hex-encoded string.
 
-## Dynamically determine server connection info
+## Dynamically Determine Server Connection Info
 
 Instead of specifying the SaltyRTC server host and port directly, you can
 instead provide an implementation of a `ServerInfoFactory` that can dynamically
@@ -164,7 +164,7 @@ determine the connection info based on the public key of the initiator.
 The signature of the function must look like this:
 
 ```typescript
-(initiatorPublicKey: string) => {host: string, port: number}
+(initiatorPublicKey: string) => { host: string, port: number }
 ```
 
 Example:

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "dist_es5_min": "rollup -c rollup/es5.min.js",
     "dist_es5_min_polyfill": "rollup -c rollup/es5.min.polyfill.js",
     "dist_es2015": "rollup -c rollup/es2015.js",
-    "rollup_tests": "rollup -c rollup/testing.js",
+    "rollup_tests": "rollup -c rollup/testing.js && rollup -c rollup/performance.js",
     "validate": "tsc --noEmit",
     "lint": "tslint -c tslint.json --project tsconfig.json",
-    "clean": "rm -rf src/*.js tests/testsuite.js*"
+    "clean": "rm -rf src/*.js tests/testsuite.js* tests/performance.js*"
   },
   "repository": {
     "type": "git",

--- a/rollup/performance.js
+++ b/rollup/performance.js
@@ -1,0 +1,7 @@
+import config from './es5.js';
+
+config.entry = 'tests/performance.ts';
+config.dest = 'tests/performance.js';
+config.sourceMap = true;
+
+export default config;

--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -19,8 +19,22 @@ declare namespace saltyrtc {
         publicKeyBytes: Uint8Array;
         secretKeyHex: string;
         secretKeyBytes: Uint8Array;
+        getSharedKeyStore(publicKey: Uint8Array | string): SharedKeyStore;
+        encryptRaw(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): Uint8Array;
         encrypt(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): Box;
+        decryptRaw(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): Uint8Array;
         decrypt(box: Box, otherKey: Uint8Array): Uint8Array;
+    }
+
+    interface SharedKeyStore {
+        localSecretKeyHex: string;
+        localSecretKeyBytes: Uint8Array
+        remotePublicKeyHex: string;
+        remotePublicKeyBytes: Uint8Array
+        encryptRaw(bytes: Uint8Array, nonce: Uint8Array): Uint8Array;
+        encrypt(bytes: Uint8Array, nonce: Uint8Array): Box;
+        decryptRaw(bytes: Uint8Array, nonce: Uint8Array): Uint8Array;
+        decrypt(box: Box): Uint8Array;
     }
 
     interface AuthToken {

--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -8,17 +8,17 @@
 declare namespace saltyrtc {
 
     interface Box {
-        length: number;
-        data: Uint8Array;
-        nonce: Uint8Array;
+        readonly length: number;
+        readonly data: Uint8Array;
+        readonly nonce: Uint8Array;
         toUint8Array(): Uint8Array;
     }
 
     interface KeyStore {
-        publicKeyHex: string;
-        publicKeyBytes: Uint8Array;
-        secretKeyHex: string;
-        secretKeyBytes: Uint8Array;
+        readonly publicKeyHex: string;
+        readonly publicKeyBytes: Uint8Array;
+        readonly secretKeyHex: string;
+        readonly secretKeyBytes: Uint8Array;
         getSharedKeyStore(publicKey: Uint8Array | string): SharedKeyStore;
         encryptRaw(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): Uint8Array;
         encrypt(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): Box;
@@ -27,10 +27,10 @@ declare namespace saltyrtc {
     }
 
     interface SharedKeyStore {
-        localSecretKeyHex: string;
-        localSecretKeyBytes: Uint8Array
-        remotePublicKeyHex: string;
-        remotePublicKeyBytes: Uint8Array
+        readonly localSecretKeyHex: string;
+        readonly localSecretKeyBytes: Uint8Array
+        readonly remotePublicKeyHex: string;
+        readonly remotePublicKeyBytes: Uint8Array
         encryptRaw(bytes: Uint8Array, nonce: Uint8Array): Uint8Array;
         encrypt(bytes: Uint8Array, nonce: Uint8Array): Box;
         decryptRaw(bytes: Uint8Array, nonce: Uint8Array): Uint8Array;
@@ -38,8 +38,8 @@ declare namespace saltyrtc {
     }
 
     interface AuthToken {
-        keyBytes: Uint8Array;
-        keyHex: string;
+        readonly keyBytes: Uint8Array;
+        readonly keyHex: string;
         encrypt(bytes: Uint8Array, nonce: Uint8Array): Box;
         decrypt(box: Box): Uint8Array;
     }

--- a/src/keystore.ts
+++ b/src/keystore.ts
@@ -178,11 +178,11 @@ export class KeyStore implements saltyrtc.KeyStore {
      * - decryption-failed: Data could not be decrypted
      */
     public decryptRaw(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): Uint8Array {
-        const data = nacl.box.open(bytes, nonce, otherKey, this._keyPair.secretKey);
+        const data: Uint8Array | null = nacl.box.open(bytes, nonce, otherKey, this._keyPair.secretKey);
         if (!data) {
             throw new CryptoError('decryption-failed', 'Data could not be decrypted');
         }
-        return data as Uint8Array;
+        return data;
     }
 
     /**
@@ -278,11 +278,11 @@ export class SharedKeyStore implements saltyrtc.SharedKeyStore {
      * - decryption-failed: Data could not be decrypted
      */
     public decryptRaw(bytes: Uint8Array, nonce: Uint8Array): Uint8Array {
-        const data = nacl.box.open.after(bytes, nonce, this._sharedKey);
+        const data: Uint8Array | null = nacl.box.open.after(bytes, nonce, this._sharedKey);
         if (!data) {
             throw new CryptoError('decryption-failed', 'Data could not be decrypted');
         }
-        return data as Uint8Array;
+        return data;
     }
 
     /**
@@ -354,11 +354,11 @@ export class AuthToken implements saltyrtc.AuthToken {
      * - decryption-failed: Data could not be decrypted
      */
     public decrypt(box: saltyrtc.Box): Uint8Array {
-        const data = nacl.secretbox.open(box.data, box.nonce, this._authToken);
+        const data: Uint8Array | null = nacl.secretbox.open(box.data, box.nonce, this._authToken);
         if (!data) {
             throw new CryptoError('decryption-failed', 'Data could not be decrypted');
         }
-        return data as Uint8Array;
+        return data;
     }
 
 }

--- a/src/keystore.ts
+++ b/src/keystore.ts
@@ -84,41 +84,57 @@ export class KeyStore implements saltyrtc.KeyStore {
 
     private logTag: string = '[SaltyRTC.KeyStore]';
 
-    constructor(privateKey?: Uint8Array | string) {
+    constructor(secretKey?: Uint8Array | string) {
         // Validate argument count (bug prevention)
         if (arguments.length > 1) {
             throw new Error('Too many arguments in KeyStore constructor');
         }
 
         // Create new key pair if necessary
-        if (privateKey === undefined) {
+        if (secretKey === undefined) {
             this._keyPair = nacl.box.keyPair();
             console.debug(this.logTag, 'New public key:', u8aToHex(this._keyPair.publicKey));
         } else {
-            this._keyPair = nacl.box.keyPair.fromSecretKey(validateKey(privateKey, 'Private key'));
+            this._keyPair = nacl.box.keyPair.fromSecretKey(validateKey(secretKey, 'Private key'));
             console.debug(this.logTag, 'Restored public key:', u8aToHex(this._keyPair.publicKey));
         }
     }
 
     /**
+     * Create a SharedKeyStore from this instance and the public key of the
+     * remote peer.
+     */
+    public getSharedKeyStore(publicKey: Uint8Array | string): SharedKeyStore {
+        return new SharedKeyStore(this.secretKeyBytes, publicKey);
+    }
+
+    /**
      * Return the public key as hex string.
      */
-    get publicKeyHex(): string { return u8aToHex(this._keyPair.publicKey); }
+    get publicKeyHex(): string {
+        return u8aToHex(this._keyPair.publicKey);
+    }
 
     /**
      * Return the public key as Uint8Array.
      */
-    get publicKeyBytes(): Uint8Array { return this._keyPair.publicKey; }
+    get publicKeyBytes(): Uint8Array {
+        return this._keyPair.publicKey;
+    }
 
     /**
      * Return the secret key as hex string.
      */
-    get secretKeyHex(): string { return u8aToHex(this._keyPair.secretKey); }
+    get secretKeyHex(): string {
+        return u8aToHex(this._keyPair.secretKey);
+    }
 
     /**
      * Return the secret key as Uint8Array.
      */
-    get secretKeyBytes(): Uint8Array { return this._keyPair.secretKey; }
+    get secretKeyBytes(): Uint8Array {
+        return this._keyPair.secretKey;
+    }
 
     /**
      * Return the full keypair.
@@ -128,14 +144,22 @@ export class KeyStore implements saltyrtc.KeyStore {
     }
 
     /**
-     * Encrypt plain data for the peer and return encrypted data as bytes.
+     * Encrypt plain data for the remote peer and return encrypted data as
+     * bytes.
+     *
+     * Note: Encrypting using a SharedKeyStore instance is more efficient when
+     *       encrypting with the same public key more than once.
      */
     public encryptRaw(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): Uint8Array {
         return nacl.box(bytes, nonce, otherKey, this._keyPair.secretKey);
     }
 
     /**
-     * Encrypt plain data for the peer and return encrypted data in a box.
+     * Encrypt plain data for the remote peer and return encrypted data in a
+     * box.
+     *
+     * Note: Encrypting using a SharedKeyStore instance is more efficient when
+     *       encrypting with the same public key more than once.
      */
     public encrypt(bytes: Uint8Array, nonce: Uint8Array, otherKey: Uint8Array): saltyrtc.Box {
         const encrypted = this.encryptRaw(bytes, nonce, otherKey);
@@ -143,7 +167,11 @@ export class KeyStore implements saltyrtc.KeyStore {
     }
 
     /**
-     * Decrypt encrypted bytes from the peer and return plain data as bytes.
+     * Decrypt encrypted bytes from the remote peer and return plain data as
+     * bytes.
+     *
+     * Note: Decrypting using a SharedKeyStore instance is more efficient when
+     *       decrypting with the same public key more than once.
      *
      * May throw CryptoError instances with the following codes:
      *
@@ -158,7 +186,11 @@ export class KeyStore implements saltyrtc.KeyStore {
     }
 
     /**
-     * Decrypt encrypted boxed data from the peer and return plain data as bytes.
+     * Decrypt encrypted boxed data from the remote peer and return plain data
+     * as bytes.
+     *
+     * Note: Decrypting using a SharedKeyStore instance is more efficient when
+     *       decrypting with the same public key more than once.
      *
      * May throw CryptoError instances with the following codes:
      *
@@ -169,13 +201,110 @@ export class KeyStore implements saltyrtc.KeyStore {
     }
 }
 
+/**
+ * A SharedKeyStore holds the resulting shared key of the local peer's secret
+ * key and the remote peer's public key.
+ *
+ * Note: Since the shared key is only calculated once, using the SharedKeyStore
+ *       should always be preferred over over using the KeyStore instance.
+ */
+export class SharedKeyStore implements saltyrtc.SharedKeyStore {
+    // The local NaCl key pair
+    private _localSecretKey: Uint8Array;
+    // The remote public key
+    private _remotePublicKey: Uint8Array;
+    // The calculated shared key
+    private _sharedKey: Uint8Array;
+
+    constructor(localSecretKey: Uint8Array | string, remotePublicKey: Uint8Array | string) {
+        this._localSecretKey = validateKey(localSecretKey, 'Local private key');
+        this._remotePublicKey = validateKey(remotePublicKey, 'Remote public key');
+
+        // Calculate the shared key
+        this._sharedKey = nacl.box.before(this._remotePublicKey, this._localSecretKey);
+    }
+
+    /**
+     * Return the local peer's secret key as hex string.
+     */
+    get localSecretKeyHex(): string {
+        return u8aToHex(this._localSecretKey);
+    }
+
+    /**
+     * Return the local peer's secret key as Uint8Array.
+     */
+    get localSecretKeyBytes(): Uint8Array {
+        return this._localSecretKey;
+    }
+
+    /**
+     * Return the remote peer's public key as a hex string.
+     */
+    get remotePublicKeyHex(): string {
+        return u8aToHex(this._remotePublicKey);
+    }
+
+    /**
+     * Return the remote peer's public key as Uint8Array.
+     */
+    get remotePublicKeyBytes(): Uint8Array {
+        return this._remotePublicKey;
+    }
+
+    /**
+     * Encrypt plain data for the remote peer and return encrypted data as
+     * bytes.
+     */
+    public encryptRaw(bytes: Uint8Array, nonce: Uint8Array): Uint8Array {
+        return nacl.box.after(bytes, nonce, this._sharedKey);
+    }
+
+    /**
+     * Encrypt plain data for the remote peer and return encrypted data in a
+     * box.
+     */
+    public encrypt(bytes: Uint8Array, nonce: Uint8Array): saltyrtc.Box {
+        const encrypted = this.encryptRaw(bytes, nonce);
+        return new Box(nonce, encrypted, nacl.box.nonceLength);
+    }
+
+    /**
+     * Decrypt encrypted bytes from the remote peer and return plain data as
+     * bytes.
+     *
+     * May throw CryptoError instances with the following codes:
+     *
+     * - decryption-failed: Data could not be decrypted
+     */
+    public decryptRaw(bytes: Uint8Array, nonce: Uint8Array): Uint8Array {
+        const data = nacl.box.open.after(bytes, nonce, this._sharedKey);
+        if (!data) {
+            throw new CryptoError('decryption-failed', 'Data could not be decrypted');
+        }
+        return data as Uint8Array;
+    }
+
+    /**
+     * Decrypt encrypted boxed data from the remote peer and return plain data
+     * as bytes.
+     *
+     * May throw CryptoError instances with the following codes:
+     *
+     * - decryption-failed: Data could not be decrypted
+     */
+    public decrypt(box: saltyrtc.Box): Uint8Array {
+        return this.decryptRaw(box.data, box.nonce);
+    }
+}
+
 export class AuthToken implements saltyrtc.AuthToken {
 
     private _authToken: Uint8Array = null;
 
     private logTag: string = '[SaltyRTC.AuthToken]';
 
-    /*
+    /**
      * May throw CryptoError instances with the following codes:
      *
      * - bad-token-length
@@ -198,12 +327,16 @@ export class AuthToken implements saltyrtc.AuthToken {
     /**
      * Return the secret key as Uint8Array.
      */
-    get keyBytes() { return this._authToken; }
+    get keyBytes() {
+        return this._authToken;
+    }
 
     /**
      * Return the secret key as hex string.
      */
-    get keyHex() { return u8aToHex(this._authToken); }
+    get keyHex() {
+        return u8aToHex(this._authToken);
+    }
 
     /**
      * Encrypt data using the shared auth token.

--- a/src/peers.ts
+++ b/src/peers.ts
@@ -54,11 +54,11 @@ export abstract class Peer {
 
     public abstract get name(): string;
 
-    public setSharedPermanentKey(remotePermanentKey: Uint8Array, localPermanentKey: saltyrtc.KeyStore) {
+    public setPermanentSharedKey(remotePermanentKey: Uint8Array, localPermanentKey: saltyrtc.KeyStore) {
         this._permanentSharedKey = localPermanentKey.getSharedKeyStore(remotePermanentKey);
     }
 
-    public setSharedSessionKey(remoteSessionKey: Uint8Array, localSessionKey: saltyrtc.KeyStore) {
+    public setSessionSharedKey(remoteSessionKey: Uint8Array, localSessionKey: saltyrtc.KeyStore) {
         this._sessionSharedKey = localSessionKey.getSharedKeyStore(remoteSessionKey);
     }
 }
@@ -77,13 +77,13 @@ export abstract class Client extends Peer {
         this._localSessionKey = localSessionKey;
     }
 
-    public setSharedSessionKey(remoteSessionKey: Uint8Array, localSessionKey?: saltyrtc.KeyStore) {
+    public setSessionSharedKey(remoteSessionKey: Uint8Array, localSessionKey?: saltyrtc.KeyStore) {
         if (!localSessionKey) {
             localSessionKey = this._localSessionKey;
         } else {
             this._localSessionKey = localSessionKey;
         }
-        super.setSharedSessionKey(remoteSessionKey, localSessionKey);
+        super.setSessionSharedKey(remoteSessionKey, localSessionKey);
     }
 }
 
@@ -100,7 +100,7 @@ export class Initiator extends Client {
 
     constructor(remotePermanentKey: Uint8Array, localPermanentKey: saltyrtc.KeyStore) {
         super(Initiator.ID);
-        this.setSharedPermanentKey(remotePermanentKey, localPermanentKey);
+        this.setPermanentSharedKey(remotePermanentKey, localPermanentKey);
     }
 
     public get name(): string {

--- a/src/signaling/common.ts
+++ b/src/signaling/common.ts
@@ -483,7 +483,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
      */
     protected handleServerHello(msg: saltyrtc.messages.ServerHello, nonce: Nonce): void {
         // Update server instance with the established session key and cookie
-        this.server.setSharedSessionKey(new Uint8Array(msg.key), this.permanentKey);
+        this.server.setSessionSharedKey(new Uint8Array(msg.key), this.permanentKey);
         this.server.cookiePair.theirs = nonce.cookie;
     }
 

--- a/src/signaling/helpers.ts
+++ b/src/signaling/helpers.ts
@@ -5,44 +5,6 @@
  * of the MIT license.  See the `LICENSE.md` file for details.
  */
 
-import { CloseCode } from '../closecode';
-import { SignalingError } from '../exceptions';
-
-/**
- * Decrypt a KeyStore. Convert errors during decryption to an appropriate SignalingError.
- *
- * @throws SignalingError
- */
-export function decryptKeystore(box: saltyrtc.Box, keyStore: saltyrtc.KeyStore, otherKey: Uint8Array,
-                                msgType?: string): Uint8Array {
-    try {
-        return keyStore.decrypt(box, otherKey);
-    } catch (e) {
-        if (e.name === 'CryptoError' && e.code === 'decryption-failed') {
-            throw new SignalingError(CloseCode.ProtocolError, 'Could not decrypt ' + msgType + ' message.');
-        } else {
-            throw e;
-        }
-    }
-}
-
-/**
- * Decrypt an AuthToken. Convert errors during decryption to an appropriate SignalingError.
- *
- * @throws SignalingError
- */
-export function decryptAuthtoken(box: saltyrtc.Box, authToken: saltyrtc.AuthToken, msgType: string): Uint8Array {
-    try {
-        return authToken.decrypt(box);
-    } catch (e) {
-        if (e.name === 'CryptoError' && e.code === 'decryption-failed') {
-            throw new SignalingError(CloseCode.ProtocolError, 'Could not decrypt ' + msgType + ' message.');
-        } else {
-            throw e;
-        }
-    }
-}
-
 /**
  * Return `true` if byte is a valid responder id (in the range 0x02-0xff).
  */

--- a/src/signaling/initiator.ts
+++ b/src/signaling/initiator.ts
@@ -131,7 +131,7 @@ export class InitiatorSignaling extends Signaling {
             responder.handshakeState = 'token-received';
 
             // Set the public permanent key.
-            responder.setSharedPermanentKey(this.peerTrustedKey, this.permanentKey);
+            responder.setPermanentSharedKey(this.peerTrustedKey, this.permanentKey);
         }
 
         // Store responder
@@ -359,7 +359,7 @@ export class InitiatorSignaling extends Signaling {
      * A responder sends his public permanent key.
      */
     private handleToken(msg: saltyrtc.messages.Token, responder: Responder): void {
-        responder.setSharedPermanentKey(new Uint8Array(msg.key), this.permanentKey);
+        responder.setPermanentSharedKey(new Uint8Array(msg.key), this.permanentKey);
         responder.handshakeState = 'token-received';
     }
 
@@ -369,7 +369,7 @@ export class InitiatorSignaling extends Signaling {
     private handleKey(msg: saltyrtc.messages.Key, responder: Responder): void {
         // Generate our own session key & generate the shared session key
         responder.setLocalSessionKey(new KeyStore());
-        responder.setSharedSessionKey(new Uint8Array(msg.key));
+        responder.setSessionSharedKey(new Uint8Array(msg.key));
         responder.handshakeState = 'key-received';
     }
 

--- a/src/signaling/responder.ts
+++ b/src/signaling/responder.ts
@@ -327,7 +327,7 @@ export class ResponderSignaling extends Signaling {
      */
     private handleKey(msg: saltyrtc.messages.Key): void {
         // Generate the shared session key
-        this.initiator.setSharedSessionKey(new Uint8Array(msg.key));
+        this.initiator.setSessionSharedKey(new Uint8Array(msg.key));
         this.initiator.handshakeState = 'key-received';
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,7 +132,7 @@ export function isString(value: any): value is string {
 }
 
 /**
- * Validate a 32 byte key.
+ * Validate a 32 byte key. Return the validated key as a Uint8Array instance.
  *
  * @param key Either an Uint8Array or a hex string.
  * @throws ValidationError if key is invalid.

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -49,7 +49,7 @@ export default () => { describe('client', function() {
                 .usingTasks(tasks)
                 .asResponder();
             expect(((salty as any).signaling as any).role).toEqual('responder');
-            expect(((salty as any).signaling as any).initiator.permanentKey).toEqual(pubKey);
+            expect(((salty as any).signaling as any).initiator.permanentSharedKey.remotePublicKeyBytes).toEqual(pubKey);
             expect(((salty as any).signaling as any).authToken.keyBytes).toEqual(authToken);
             expect(((salty as any).signaling as any).peerTrustedKey).toBeNull();
             expect(((salty as any).signaling as any).tasks).toEqual(tasks);
@@ -67,7 +67,7 @@ export default () => { describe('client', function() {
                 .asResponder();
             expect(((salty as any).signaling as any).role).toEqual('responder');
             expect(((salty as any).signaling as any).peerTrustedKey).toEqual(trustedKey);
-            expect(((salty as any).signaling as any).initiator.permanentKey).toEqual(trustedKey);
+            expect(((salty as any).signaling as any).initiator.permanentSharedKey.remotePublicKeyBytes).toEqual(trustedKey);
             expect(((salty as any).signaling as any).authToken).toBeNull();
             expect(((salty as any).signaling as any).tasks).toEqual(tasks);
             expect(((salty as any).signaling as any).pingInterval).toEqual(0);
@@ -82,7 +82,7 @@ export default () => { describe('client', function() {
                 .initiatorInfo(u8aToHex(pubKey), u8aToHex(authToken))
                 .usingTasks([new DummyTask()])
                 .asResponder();
-            expect(((salty as any).signaling as any).initiator.permanentKey).toEqual(pubKey);
+            expect(((salty as any).signaling as any).initiator.permanentSharedKey.remotePublicKeyBytes).toEqual(pubKey);
             expect(((salty as any).signaling as any).authToken.keyBytes).toEqual(authToken);
         });
 

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -6,5 +6,5 @@ export class Config {
     public static RUN_LOAD_TESTS = false;
 
     // Performance test configuration
-    public static CRYPTO_ITERATIONS = 10240;
+    public static CRYPTO_ITERATIONS = 2048;
 }

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -1,6 +1,10 @@
 export class Config {
+    // Unit test configuration
     public static SALTYRTC_HOST = 'localhost';
     public static SALTYRTC_PORT = 8765;
     public static SALTYRTC_SERVER_PUBLIC_KEY = '09a59a5fa6b45cb07638a3a6e347ce563a948b756fd22f9527465f7c79c2a864';
     public static RUN_LOAD_TESTS = false;
+
+    // Performance test configuration
+    public static CRYPTO_ITERATIONS = 10240;
 }

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -6,5 +6,5 @@ export class Config {
     public static RUN_LOAD_TESTS = false;
 
     // Performance test configuration
-    public static CRYPTO_ITERATIONS = 2048;
+    public static CRYPTO_ITERATIONS = 4096;
 }

--- a/tests/keystore.spec.ts
+++ b/tests/keystore.spec.ts
@@ -1,18 +1,18 @@
 /// <reference path="jasmine.d.ts" />
 
-import { CryptoError } from '../src/exceptions';
-import { Box, KeyStore, AuthToken } from '../src/keystore';
-import { u8aToHex } from '../src/utils';
+import { CryptoError, ValidationError } from '../src/exceptions';
+import { Box, KeyStore, SharedKeyStore, AuthToken } from '../src/keystore';
+import { hexToU8a, u8aToHex } from '../src/utils';
 
-declare var nacl: any; // TODO
+declare const nacl: any; // TODO
 
 export default () => { describe('keystore', function() {
 
     describe('Box', function() {
 
-        let nonce = nacl.randomBytes(24);
-        let data = nacl.randomBytes(7);
-        let box = new Box(nonce, data, 24);
+        const nonce = nacl.randomBytes(24);
+        const data = nacl.randomBytes(7);
+        const box = new Box(nonce, data, 24);
 
         it('correctly calculates the length', () => {
             expect(box.length).toEqual(7 + 24);
@@ -27,28 +27,28 @@ export default () => { describe('keystore', function() {
         });
 
         it('can be created from a byte array', () => {
-            let nonceLength = nacl.box.nonceLength;
-            let nonce = nacl.randomBytes(nonceLength);
-            let data = nacl.randomBytes(5);
-            let array = new Uint8Array(nonceLength + 5)
+            const nonceLength = nacl.box.nonceLength;
+            const nonce = nacl.randomBytes(nonceLength);
+            const data = nacl.randomBytes(5);
+            const array = new Uint8Array(nonceLength + 5)
             array.set(nonce);
             array.set(data, nonceLength);
-            let box = Box.fromUint8Array(array, nonceLength);
+            const box = Box.fromUint8Array(array, nonceLength);
             expect(box.nonce).toEqual(nonce);
             expect(box.data).toEqual(data);
             expect(box.length).toEqual(nonceLength + 5);
         });
 
         it('validates the byte array length', () => {
-            let nonceLength = nacl.box.nonceLength;
-            let boxSameLength = () => Box.fromUint8Array(nacl.randomBytes(nonceLength), nonceLength);
-            let boxLessLength = () => Box.fromUint8Array(nacl.randomBytes(nonceLength - 2), nonceLength);
+            const nonceLength = nacl.box.nonceLength;
+            const boxSameLength = () => Box.fromUint8Array(nacl.randomBytes(nonceLength), nonceLength);
+            const boxLessLength = () => Box.fromUint8Array(nacl.randomBytes(nonceLength - 2), nonceLength);
             expect(boxSameLength).toThrow(new CryptoError('bad-message-length', 'Message is shorter than nonce'));
             expect(boxLessLength).toThrow(new CryptoError('bad-message-length', 'Message is shorter than nonce'));
         });
 
         it('can be converted into a byte array', () => {
-            let array = box.toUint8Array();
+            const array = box.toUint8Array();
             expect(array.slice(0, nacl.secretbox.nonceLength)).toEqual(nonce);
             expect(array.slice(nacl.secretbox.nonceLength)).toEqual(data);
         });
@@ -57,9 +57,9 @@ export default () => { describe('keystore', function() {
 
     describe('KeyStore', function() {
 
-        let ks = new KeyStore();
-        let nonce = nacl.randomBytes(24);
-        let data = nacl.randomBytes(7);
+        const ks = new KeyStore();
+        const nonce = nacl.randomBytes(24);
+        const data = nacl.randomBytes(7);
 
         it('generates a keypair', () => {
             // Internal test
@@ -82,8 +82,8 @@ export default () => { describe('keystore', function() {
         });
 
         it('can encrypt and decrypt properly (round trip)', () => {
-            let ks2 = new KeyStore();
-            let expected = nacl.randomBytes(24);
+            const ks2 = new KeyStore();
+            const expected = nacl.randomBytes(24);
             let encrypted, decrypted;
 
             encrypted = ks.encrypt(expected, nonce, ks2.publicKeyBytes);
@@ -93,7 +93,7 @@ export default () => { describe('keystore', function() {
             expect(decrypted).toEqual(expected);
 
             encrypted = ks.encryptRaw(expected, nonce, ks2.publicKeyBytes);
-            let encryptedBox = new Box(nonce, encrypted, nacl.box.nonceLength);
+            const encryptedBox = new Box(nonce, encrypted, nacl.box.nonceLength);
             decrypted = ks.decrypt(encryptedBox, ks2.publicKeyBytes);
             expect(decrypted).toEqual(expected);
             decrypted = ks.decryptRaw(encrypted, nonce, ks2.publicKeyBytes);
@@ -101,29 +101,29 @@ export default () => { describe('keystore', function() {
         });
 
         it('can only encrypt and decrypt if pubkey matches', () => {
-            let ks2 = new KeyStore();
-            let ks3 = new KeyStore();
-            let expected = nacl.randomBytes(24);
-            let encrypted = ks.encrypt(expected, nonce, ks2.publicKeyBytes);
+            const ks2 = new KeyStore();
+            const ks3 = new KeyStore();
+            const expected = nacl.randomBytes(24);
+            const encrypted = ks.encrypt(expected, nonce, ks2.publicKeyBytes);
 
-            let decrypts = [
+            const decrypts = [
                 () => ks.decrypt(encrypted, ks3.publicKeyBytes),
                 () => ks.decryptRaw(encrypted.data, encrypted.nonce, ks3.publicKeyBytes),
             ];
 
-            for (let decrypt of decrypts) {
-                let error = new CryptoError('decryption-failed', 'Data could not be decrypted');
+            for (const decrypt of decrypts) {
+                const error = new CryptoError('decryption-failed', 'Data could not be decrypted');
                 expect(decrypt).toThrow(error);
             }
         });
 
         it('cannot encrypt without a proper nonce', () => {
-            let encrypts = [
+            const encrypts = [
                 () => ks.encrypt(data, nacl.randomBytes(3), nacl.randomBytes(32)),
                 () => ks.encryptRaw(data, nacl.randomBytes(3), nacl.randomBytes(32)),
             ];
 
-            for (let encrypt of encrypts) {
+            for (const encrypt of encrypts) {
                 expect(encrypt).toThrow(new Error('bad nonce size'));
             }
         });
@@ -132,10 +132,10 @@ export default () => { describe('keystore', function() {
             const skBytes = nacl.randomBytes(32);
             const skHex = u8aToHex(skBytes);
 
-            let ksBytes = new KeyStore(skBytes);
-            let ksHex = new KeyStore(skHex);
+            const ksBytes = new KeyStore(skBytes);
+            const ksHex = new KeyStore(skHex);
 
-            for (let ks of [ksBytes, ksHex]) {
+            for (const ks of [ksBytes, ksHex]) {
                 expect(ks.publicKeyBytes).not.toBeNull();
                 expect(ks.secretKeyBytes).toEqual(skBytes);
                 expect(ks.publicKeyHex).not.toBeNull();
@@ -156,9 +156,83 @@ export default () => { describe('keystore', function() {
 
     });
 
+    describe('SharedKeyStore', function() {
+        const ks = new KeyStore(new Uint8Array(32).fill(0xff));
+        const sks = ks.getSharedKeyStore(ks.publicKeyBytes);
+
+        const nonce = new Uint8Array(24).fill(0xff);
+        const data = new Uint8Array(10).fill(0xff);
+
+        it('calculates the shared key', () => {
+            const key = hexToU8a('9cfcb55fa42de280c84c95d9cf08fcbec63657998d15e139dbd3b4c6a1264541');
+            expect((sks as any)._sharedKey).toEqual(key);
+        });
+
+        it('can be derived from a KeyStore', () => {
+            expect(sks.localSecretKeyBytes).toEqual(ks.secretKeyBytes);
+            expect(sks.localSecretKeyHex).toEqual(ks.secretKeyHex);
+            expect(sks.remotePublicKeyBytes).toEqual(ks.publicKeyBytes);
+            expect(sks.remotePublicKeyHex).toEqual(ks.publicKeyHex);
+        });
+
+        it('can be constructed from Uint8Array based keys', () => {
+            const sks = new SharedKeyStore(ks.secretKeyBytes, ks.publicKeyBytes);
+            expect(sks.localSecretKeyBytes).toEqual(ks.secretKeyBytes);
+            expect(sks.localSecretKeyHex).toEqual(ks.secretKeyHex);
+            expect(sks.remotePublicKeyBytes).toEqual(ks.publicKeyBytes);
+            expect(sks.remotePublicKeyHex).toEqual(ks.publicKeyHex);
+        });
+
+        it('can be constructed from hex string based keys', () => {
+            const sks = new SharedKeyStore(ks.secretKeyHex, ks.publicKeyHex);
+            expect(sks.localSecretKeyBytes).toEqual(ks.secretKeyBytes);
+            expect(sks.localSecretKeyHex).toEqual(ks.secretKeyHex);
+            expect(sks.remotePublicKeyBytes).toEqual(ks.publicKeyBytes);
+            expect(sks.remotePublicKeyHex).toEqual(ks.publicKeyHex);
+        });
+
+        it('rejects invalid keys', () => {
+            let create, error;
+
+            create = () => new SharedKeyStore({ meow: true } as any, ks.publicKeyBytes);
+            error = new ValidationError('Local private key must be an Uint8Array or a hex string');
+            expect(create).toThrow(error);
+
+            create = () => new SharedKeyStore(ks.secretKeyBytes, { meow: true } as any);
+            error = new ValidationError('Remote public key must be an Uint8Array or a hex string');
+            expect(create).toThrow(error);
+        });
+
+        it('can encrypt and decrypt properly (round trip)', () => {
+            const expected = new Uint8Array(24).fill(0xee);
+            let encrypted;
+
+            encrypted = sks.encrypt(expected, nonce);
+            expect(sks.decrypt(encrypted)).toEqual(expected);
+            expect(sks.decryptRaw(encrypted.data, encrypted.nonce)).toEqual(expected);
+
+            encrypted = sks.encryptRaw(expected, nonce);
+            const encryptedBox = new Box(nonce, encrypted, nacl.box.nonceLength);
+            expect(sks.decrypt(encryptedBox)).toEqual(expected);
+            expect(sks.decryptRaw(encrypted, nonce)).toEqual(expected);
+        });
+
+        it('cannot encrypt without a proper nonce', () => {
+            const encrypts = [
+                () => sks.encrypt(data, nacl.randomBytes(3)),
+                () => sks.encryptRaw(data, nacl.randomBytes(3)),
+            ];
+
+            for (const encrypt of encrypts) {
+                expect(encrypt).toThrow(new Error('bad nonce size'));
+            }
+        });
+
+    });
+
     describe('AuthToken', function() {
 
-        let at = new AuthToken();
+        const at = new AuthToken();
 
         it('can return the secret key as bytes', () => {
             expect(at.keyBytes).toBeTruthy();
@@ -171,8 +245,8 @@ export default () => { describe('keystore', function() {
         });
 
         it('can encrypt and decrypt properly (round trip)', () => {
-            let expected = nacl.randomBytes(7);
-            let nonce = nacl.randomBytes(24);
+            const expected = nacl.randomBytes(7);
+            const nonce = nacl.randomBytes(24);
             expect(at.encrypt(expected, nonce)).not.toEqual(expected);
             expect(at.decrypt(at.encrypt(expected, nonce))).toEqual(expected);
         });

--- a/tests/keystore.spec.ts
+++ b/tests/keystore.spec.ts
@@ -228,6 +228,17 @@ export default () => { describe('keystore', function() {
             }
         });
 
+        it('can encrypt/decrypt data from KeyStore', () => {
+            const expected = new Uint8Array(24).fill(0xee);
+            let encrypted;
+
+            encrypted = ks.encrypt(expected, nonce, ks.publicKeyBytes);
+            expect(sks.decrypt(encrypted)).toEqual(expected);
+
+            encrypted = sks.encrypt(expected, nonce);
+            expect(ks.decrypt(encrypted, ks.publicKeyBytes)).toEqual(expected);
+        });
+
     });
 
     describe('AuthToken', function() {

--- a/tests/performance.html
+++ b/tests/performance.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!-- Open this file in your web browser to run the performance tests. -->
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html;charset=utf-8">
+        <title>SaltyRTC Performance Tests</title>
+
+        <link rel="stylesheet" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
+
+        <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+        <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+        <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
+
+        <script src="../node_modules/tweetnacl/nacl-fast.min.js"></script>
+        <script src="../node_modules/msgpack-lite/dist/msgpack.min.js"></script>
+
+        <script src="performance.js"></script>
+    </head>
+    <body>
+    <script>
+        it('testing works', function(){
+            expect(true).toEqual(true);
+        });
+    </script>
+    </body>
+</html>

--- a/tests/performance.ts
+++ b/tests/performance.ts
@@ -1,0 +1,8 @@
+import "../node_modules/babel-es6-polyfill/browser-polyfill";
+
+import test_crypto from "./performance/crypto.spec";
+
+var counter = 1;
+beforeEach(() => console.info('------ TEST', counter++, 'BEGIN ------'));
+
+test_crypto();

--- a/tests/performance/crypto.spec.ts
+++ b/tests/performance/crypto.spec.ts
@@ -1,34 +1,195 @@
-/// <reference path="jasmine.d.ts" />
+/// <reference path="../jasmine.d.ts" />
 
 import { KeyStore } from '../../src/keystore';
-import { Config } from './../config';
+import { Config } from '../config';
 import { testData } from './utils';
 
-export default () => { describe('crypto', function() {
+export default () => {
+    describe('crypto', () => {
+        describe('Main Thread', () => {
+            it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
+                const keyStore = new KeyStore();
+                const publicKey = keyStore.publicKeyBytes;
+                const start = performance.now();
 
-    it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
-        const keyStore = new KeyStore();
-        const publicKey = keyStore.publicKeyBytes;
+                for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+                    keyStore.encrypt(testData.bytes, testData.nonce, publicKey);
+                }
 
-        const start = performance.now();
-        for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
-            keyStore.encrypt(testData.plain, testData.nonce, publicKey);
-        }
-        const end = performance.now();
-        console.info(`Took ${(end - start) / 1000} seconds`);
+                const end = performance.now();
+                console.info(`Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
+            }, 30000);
+
+            it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
+                const keyStore = new KeyStore();
+                const publicKey = keyStore.publicKeyBytes;
+                const box = keyStore.encrypt(testData.bytes, testData.nonce, publicKey);
+                const start = performance.now();
+
+                for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+                    keyStore.decrypt(box, publicKey);
+                }
+
+                const end = performance.now();
+                console.info(`Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
+            }, 30000);
+        });
+
+        describe('Web Worker', () => {
+            it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                expect(window.Worker).toBeDefined();
+                const worker = new Worker('performance/crypto.worker.js');
+                let iterations = 0;
+                worker.onmessage = () => {
+                    ++iterations;
+
+                    // All encryption tasks resolved?
+                    if (iterations === Config.CRYPTO_ITERATIONS) {
+                        worker.terminate();
+                        const end = performance.now();
+                        console.info(`Took ${(end - start) / 1000} seconds`);
+                        done();
+                    }
+                };
+
+                // Initialise worker as an encrypt worker
+                const keyStore = new KeyStore();
+                worker.postMessage({
+                    type: 'encrypt',
+                    privateKey: keyStore.secretKeyBytes,
+                });
+                const start = performance.now();
+
+                // Enqueue encryption tasks
+                for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+                    worker.postMessage({
+                        bytes: testData.bytes,
+                        nonce: testData.nonce,
+                    });
+                }
+            }, 30000);
+
+            it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                expect(window.Worker).toBeDefined();
+                const worker = new Worker('performance/crypto.worker.js');
+                let iterations = 0;
+                worker.onmessage = () => {
+                    ++iterations;
+
+                    // All decryption tasks resolved?
+                    if (iterations === Config.CRYPTO_ITERATIONS) {
+                        worker.terminate();
+                        const end = performance.now();
+                        console.info(`Took ${(end - start) / 1000} seconds`);
+                        done();
+                    }
+                };
+
+                // Initialise worker as a decrypt worker
+                const keyStore = new KeyStore();
+                const publicKey = keyStore.publicKeyBytes;
+                const box = keyStore.encrypt(testData.bytes, testData.nonce, publicKey);
+                worker.postMessage({
+                    type: 'decrypt',
+                    privateKey: keyStore.secretKeyBytes,
+                });
+                const start = performance.now();
+
+                // Enqueue encryption tasks
+                for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+                    worker.postMessage({
+                        bytes: box.data,
+                        nonce: box.nonce,
+                    });
+                }
+            }, 30000);
+        });
+
+        describe('Web Worker (Transferables)', () => {
+            it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                expect(window.Worker).toBeDefined();
+
+                const worker = new Worker('performance/crypto.worker.js');
+                let iterations = 0;
+                worker.onmessage = () => {
+                    ++iterations;
+
+                    // All encryption tasks resolved?
+                    if (iterations === Config.CRYPTO_ITERATIONS) {
+                        worker.terminate();
+                        const end = performance.now();
+                        console.info(`Took ${(end - start) / 1000} seconds`);
+                        done();
+                    }
+                };
+
+                // Initialise worker as an encrypt worker
+                const keyStore = new KeyStore();
+                const testDataArray = Array.from({ length: Config.CRYPTO_ITERATIONS }, () => {
+                    // Need to copy the plain data, so it can be transferred
+                    return testData.bytes.slice(0);
+                });
+                worker.postMessage({
+                    type: 'encrypt-transferable',
+                    privateKey: keyStore.secretKeyBytes,
+                });
+                const start = performance.now();
+
+                // Enqueue encryption tasks
+                for (const testData_ of testDataArray) {
+                    expect(testData_.buffer.byteLength).toBeGreaterThan(0);
+                    worker.postMessage({
+                        bytes: testData_,
+                        nonce: testData.nonce,
+                    }, [testData_.buffer]);
+                    expect(testData_.buffer.byteLength).toBe(0);
+                    expect(testData.nonce.buffer.byteLength).toBeGreaterThan(0);
+                }
+            }, 60000);
+
+            it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                expect(window.Worker).toBeDefined();
+
+                const worker = new Worker('performance/crypto.worker.js');
+                let iterations = 0;
+                worker.onmessage = () => {
+                    ++iterations;
+
+                    // All decryption tasks resolved?
+                    if (iterations === Config.CRYPTO_ITERATIONS) {
+                        worker.terminate();
+                        const end = performance.now();
+                        console.info(`Took ${(end - start) / 1000} seconds`);
+                        done();
+                    }
+                };
+
+                // Initialise worker as a decrypt worker
+                const keyStore = new KeyStore();
+                const publicKey = keyStore.publicKeyBytes;
+                const boxes = Array.from({ length: Config.CRYPTO_ITERATIONS }, () => {
+                    // Need to generate new data, so it can be transferred
+                    return keyStore.encrypt(testData.bytes, testData.nonce, publicKey);
+                });
+                worker.postMessage({
+                    type: 'decrypt-transferable',
+                    privateKey: keyStore.secretKeyBytes,
+                });
+                const start = performance.now();
+
+                // Enqueue encryption tasks
+                for (const box of boxes) {
+                    expect(box.data.buffer.byteLength).toBeGreaterThan(0);
+                    worker.postMessage({
+                        bytes: box.data,
+                        nonce: box.nonce,
+                    }, [box.data.buffer]);
+                    expect(box.data.buffer.byteLength).toBe(0);
+                    expect(box.nonce.buffer.byteLength).toBeGreaterThan(0);
+                }
+            }, 60000);
+        });
     });
-
-    it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
-        const keyStore = new KeyStore();
-        const publicKey = keyStore.publicKeyBytes;
-        const box = keyStore.encrypt(testData.plain, testData.nonce, publicKey);
-
-        const start = performance.now();
-        for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
-            keyStore.decrypt(box, publicKey);
-        }
-        const end = performance.now();
-        console.info(`Took ${(end - start) / 1000} seconds`);
-    });
-
-}); }
+};

--- a/tests/performance/crypto.spec.ts
+++ b/tests/performance/crypto.spec.ts
@@ -6,7 +6,7 @@ import { testData } from './utils';
 
 export default () => {
     describe('crypto', () => {
-        describe('Main Thread', () => {
+        describe('Main Thread (shared key store=false)', () => {
             it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
                 const keyStore = new KeyStore();
                 const publicKey = keyStore.publicKeyBytes;
@@ -37,159 +37,196 @@ export default () => {
             }, 30000);
         });
 
-        describe('Web Worker', () => {
-            it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
-                expect(window.Worker).toBeDefined();
-                const worker = new Worker('performance/crypto.worker.js');
-                let iterations = 0;
-                worker.onmessage = () => {
-                    ++iterations;
-
-                    // All encryption tasks resolved?
-                    if (iterations === Config.CRYPTO_ITERATIONS) {
-                        worker.terminate();
-                        const end = performance.now();
-                        console.info(`Took ${(end - start) / 1000} seconds`);
-                        done();
-                    }
-                };
-
-                // Initialise worker as an encrypt worker
+        describe('Main Thread (shared key store=true)', () => {
+            it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
                 const keyStore = new KeyStore();
-                worker.postMessage({
-                    type: 'encrypt',
-                    privateKey: keyStore.secretKeyBytes,
-                });
+                const sharedKeyStore = keyStore.getSharedKeyStore(keyStore.publicKeyBytes);
                 const start = performance.now();
 
-                // Enqueue encryption tasks
                 for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
-                    worker.postMessage({
-                        bytes: testData.bytes,
-                        nonce: testData.nonce,
-                    });
+                    sharedKeyStore.encrypt(testData.bytes, testData.nonce);
                 }
+
+                const end = performance.now();
+                console.info(`Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
             }, 30000);
 
-            it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
-                expect(window.Worker).toBeDefined();
-                const worker = new Worker('performance/crypto.worker.js');
-                let iterations = 0;
-                worker.onmessage = () => {
-                    ++iterations;
-
-                    // All decryption tasks resolved?
-                    if (iterations === Config.CRYPTO_ITERATIONS) {
-                        worker.terminate();
-                        const end = performance.now();
-                        console.info(`Took ${(end - start) / 1000} seconds`);
-                        done();
-                    }
-                };
-
-                // Initialise worker as a decrypt worker
+            it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
                 const keyStore = new KeyStore();
-                const publicKey = keyStore.publicKeyBytes;
-                const box = keyStore.encrypt(testData.bytes, testData.nonce, publicKey);
-                worker.postMessage({
-                    type: 'decrypt',
-                    privateKey: keyStore.secretKeyBytes,
-                });
+                const sharedKeyStore = keyStore.getSharedKeyStore(keyStore.publicKeyBytes);
+                const box = sharedKeyStore.encrypt(testData.bytes, testData.nonce);
                 const start = performance.now();
 
-                // Enqueue encryption tasks
                 for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
-                    worker.postMessage({
-                        bytes: box.data,
-                        nonce: box.nonce,
-                    });
+                    sharedKeyStore.decrypt(box);
                 }
+
+                const end = performance.now();
+                console.info(`Took ${(end - start) / 1000} seconds`);
+                expect(0).toBe(0);
             }, 30000);
         });
 
-        describe('Web Worker (Transferables)', () => {
-            it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
-                expect(window.Worker).toBeDefined();
+        [false, true].forEach((useSharedKeyStore) => {
+            describe(`Web Worker (shared key store=${useSharedKeyStore}, transferables=false)`, () => {
+                it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                    expect(window.Worker).toBeDefined();
+                    const worker = new Worker('performance/crypto.worker.js');
+                    let iterations = 0;
+                    worker.onmessage = () => {
+                        ++iterations;
 
-                const worker = new Worker('performance/crypto.worker.js');
-                let iterations = 0;
-                worker.onmessage = () => {
-                    ++iterations;
+                        // All encryption tasks resolved?
+                        if (iterations === Config.CRYPTO_ITERATIONS) {
+                            worker.terminate();
+                            const end = performance.now();
+                            console.info(`Took ${(end - start) / 1000} seconds`);
+                            done();
+                        }
+                    };
 
-                    // All encryption tasks resolved?
-                    if (iterations === Config.CRYPTO_ITERATIONS) {
-                        worker.terminate();
-                        const end = performance.now();
-                        console.info(`Took ${(end - start) / 1000} seconds`);
-                        done();
-                    }
-                };
-
-                // Initialise worker as an encrypt worker
-                const keyStore = new KeyStore();
-                const testDataArray = Array.from({ length: Config.CRYPTO_ITERATIONS }, () => {
-                    // Need to copy the plain data, so it can be transferred
-                    return testData.bytes.slice(0);
-                });
-                worker.postMessage({
-                    type: 'encrypt-transferable',
-                    privateKey: keyStore.secretKeyBytes,
-                });
-                const start = performance.now();
-
-                // Enqueue encryption tasks
-                for (const testData_ of testDataArray) {
-                    expect(testData_.buffer.byteLength).toBeGreaterThan(0);
+                    // Initialise worker as an encrypt worker
+                    const keyStore = new KeyStore();
                     worker.postMessage({
-                        bytes: testData_,
-                        nonce: testData.nonce,
-                    }, [testData_.buffer]);
-                    expect(testData_.buffer.byteLength).toBe(0);
-                    expect(testData.nonce.buffer.byteLength).toBeGreaterThan(0);
-                }
-            }, 60000);
+                        type: 'encrypt',
+                        secretKey: keyStore.secretKeyBytes,
+                        useSharedKeyStore: useSharedKeyStore,
+                    });
+                    const start = performance.now();
 
-            it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
-                expect(window.Worker).toBeDefined();
-
-                const worker = new Worker('performance/crypto.worker.js');
-                let iterations = 0;
-                worker.onmessage = () => {
-                    ++iterations;
-
-                    // All decryption tasks resolved?
-                    if (iterations === Config.CRYPTO_ITERATIONS) {
-                        worker.terminate();
-                        const end = performance.now();
-                        console.info(`Took ${(end - start) / 1000} seconds`);
-                        done();
+                    // Enqueue encryption tasks
+                    for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+                        worker.postMessage({
+                            bytes: testData.bytes,
+                            nonce: testData.nonce,
+                        });
                     }
-                };
+                }, 30000);
 
-                // Initialise worker as a decrypt worker
-                const keyStore = new KeyStore();
-                const publicKey = keyStore.publicKeyBytes;
-                const boxes = Array.from({ length: Config.CRYPTO_ITERATIONS }, () => {
-                    // Need to generate new data, so it can be transferred
-                    return keyStore.encrypt(testData.bytes, testData.nonce, publicKey);
-                });
-                worker.postMessage({
-                    type: 'decrypt-transferable',
-                    privateKey: keyStore.secretKeyBytes,
-                });
-                const start = performance.now();
+                it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                    expect(window.Worker).toBeDefined();
+                    const worker = new Worker('performance/crypto.worker.js');
+                    let iterations = 0;
+                    worker.onmessage = () => {
+                        ++iterations;
 
-                // Enqueue encryption tasks
-                for (const box of boxes) {
-                    expect(box.data.buffer.byteLength).toBeGreaterThan(0);
+                        // All decryption tasks resolved?
+                        if (iterations === Config.CRYPTO_ITERATIONS) {
+                            worker.terminate();
+                            const end = performance.now();
+                            console.info(`Took ${(end - start) / 1000} seconds`);
+                            done();
+                        }
+                    };
+
+                    // Initialise worker as a decrypt worker
+                    const keyStore = new KeyStore();
+                    const sharedKeyStore = keyStore.getSharedKeyStore(keyStore.publicKeyBytes);
+                    const box = sharedKeyStore.encrypt(testData.bytes, testData.nonce);
                     worker.postMessage({
-                        bytes: box.data,
-                        nonce: box.nonce,
-                    }, [box.data.buffer]);
-                    expect(box.data.buffer.byteLength).toBe(0);
-                    expect(box.nonce.buffer.byteLength).toBeGreaterThan(0);
-                }
-            }, 60000);
+                        type: 'decrypt',
+                        secretKey: keyStore.secretKeyBytes,
+                        useSharedKeyStore: useSharedKeyStore,
+                    });
+                    const start = performance.now();
+
+                    // Enqueue encryption tasks
+                    for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+                        worker.postMessage({
+                            bytes: box.data,
+                            nonce: box.nonce,
+                        });
+                    }
+                }, 30000);
+            });
+
+            describe(`Web Worker (shared key store=${useSharedKeyStore}, transferables=true)`, () => {
+                it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                    expect(window.Worker).toBeDefined();
+
+                    const worker = new Worker('performance/crypto.worker.js');
+                    let iterations = 0;
+                    worker.onmessage = () => {
+                        ++iterations;
+
+                        // All encryption tasks resolved?
+                        if (iterations === Config.CRYPTO_ITERATIONS) {
+                            worker.terminate();
+                            const end = performance.now();
+                            console.info(`Took ${(end - start) / 1000} seconds`);
+                            done();
+                        }
+                    };
+
+                    // Initialise worker as an encrypt worker
+                    const keyStore = new KeyStore();
+                    const testDataArray = Array.from({ length: Config.CRYPTO_ITERATIONS }, () => {
+                        // Need to copy the plain data, so it can be transferred
+                        return testData.bytes.slice(0);
+                    });
+                    worker.postMessage({
+                        type: 'encrypt-transferable',
+                        secretKey: keyStore.secretKeyBytes,
+                        useSharedKeyStore: useSharedKeyStore,
+                    });
+                    const start = performance.now();
+
+                    // Enqueue encryption tasks
+                    for (const testData_ of testDataArray) {
+                        expect(testData_.buffer.byteLength).toBeGreaterThan(0);
+                        worker.postMessage({
+                            bytes: testData_,
+                            nonce: testData.nonce,
+                        }, [testData_.buffer]);
+                        expect(testData_.buffer.byteLength).toBe(0);
+                        expect(testData.nonce.buffer.byteLength).toBeGreaterThan(0);
+                    }
+                }, 60000);
+
+                it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                    expect(window.Worker).toBeDefined();
+
+                    const worker = new Worker('performance/crypto.worker.js');
+                    let iterations = 0;
+                    worker.onmessage = () => {
+                        ++iterations;
+
+                        // All decryption tasks resolved?
+                        if (iterations === Config.CRYPTO_ITERATIONS) {
+                            worker.terminate();
+                            const end = performance.now();
+                            console.info(`Took ${(end - start) / 1000} seconds`);
+                            done();
+                        }
+                    };
+
+                    // Initialise worker as a decrypt worker
+                    const keyStore = new KeyStore();
+                    const sharedKeyStore = keyStore.getSharedKeyStore(keyStore.publicKeyBytes);
+                    const boxes = Array.from({ length: Config.CRYPTO_ITERATIONS }, () => {
+                        // Need to generate new data, so it can be transferred
+                        return sharedKeyStore.encrypt(testData.bytes, testData.nonce);
+                    });
+                    worker.postMessage({
+                        type: 'decrypt-transferable',
+                        secretKey: keyStore.secretKeyBytes,
+                        useSharedKeyStore: useSharedKeyStore,
+                    });
+                    const start = performance.now();
+
+                    // Enqueue encryption tasks
+                    for (const box of boxes) {
+                        expect(box.data.buffer.byteLength).toBeGreaterThan(0);
+                        worker.postMessage({
+                            bytes: box.data,
+                            nonce: box.nonce,
+                        }, [box.data.buffer]);
+                        expect(box.data.buffer.byteLength).toBe(0);
+                        expect(box.nonce.buffer.byteLength).toBeGreaterThan(0);
+                    }
+                }, 60000);
+            });
         });
     });
 };

--- a/tests/performance/crypto.spec.ts
+++ b/tests/performance/crypto.spec.ts
@@ -1,0 +1,34 @@
+/// <reference path="jasmine.d.ts" />
+
+import { KeyStore } from '../../src/keystore';
+import { Config } from './../config';
+import { testData } from './utils';
+
+export default () => { describe('crypto', function() {
+
+    it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
+        const keyStore = new KeyStore();
+        const publicKey = keyStore.publicKeyBytes;
+
+        const start = performance.now();
+        for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+            keyStore.encrypt(testData.plain, testData.nonce, publicKey);
+        }
+        const end = performance.now();
+        console.info(`Took ${(end - start) / 1000} seconds`);
+    });
+
+    it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, () => {
+        const keyStore = new KeyStore();
+        const publicKey = keyStore.publicKeyBytes;
+        const box = keyStore.encrypt(testData.plain, testData.nonce, publicKey);
+
+        const start = performance.now();
+        for (let i = 0; i <= Config.CRYPTO_ITERATIONS; ++i) {
+            keyStore.decrypt(box, publicKey);
+        }
+        const end = performance.now();
+        console.info(`Took ${(end - start) / 1000} seconds`);
+    });
+
+}); }

--- a/tests/performance/crypto.worker.js
+++ b/tests/performance/crypto.worker.js
@@ -1,0 +1,54 @@
+'use strict';
+
+importScripts(
+    '../../node_modules/tweetnacl/nacl-fast.js',
+    '../../node_modules/msgpack-lite/dist/msgpack.min.js',
+    '../../dist/saltyrtc-client.es5.min.js',
+);
+
+let keyStore;
+let publicKey;
+
+function encrypt(e) {
+    const cipher = keyStore.encryptRaw(e.data.bytes, e.data.nonce, publicKey);
+    postMessage(cipher);
+}
+
+function encryptTransferable(e) {
+    const cipher = keyStore.encryptRaw(e.data.bytes, e.data.nonce, publicKey);
+    postMessage(cipher, [cipher.buffer]);
+}
+
+function decrypt(e) {
+    const plain = keyStore.decryptRaw(e.data.bytes, e.data.nonce, publicKey);
+    postMessage(plain);
+}
+
+function decryptTransferable(e) {
+    const plain = keyStore.decryptRaw(e.data.bytes, e.data.nonce, publicKey);
+    postMessage(plain, [plain.buffer]);
+}
+
+addEventListener('message', (e) => {
+    keyStore = new saltyrtcClient.KeyStore(e.data.privateKey);
+    publicKey = keyStore.publicKeyBytes;
+
+    switch (e.data.type) {
+        case 'encrypt':
+            addEventListener('message', encrypt);
+            break;
+        case 'decrypt':
+            addEventListener('message', decrypt);
+            break;
+        case 'encrypt-transferable':
+            addEventListener('message', encryptTransferable);
+            break;
+        case 'decrypt-transferable':
+            addEventListener('message', decryptTransferable);
+            break;
+        default:
+            console.error('Unable to determine role');
+            close();
+            break;
+    }
+}, { once: true });

--- a/tests/performance/utils.ts
+++ b/tests/performance/utils.ts
@@ -8,6 +8,6 @@
  */
 
 export const testData = {
-    plain: new Uint8Array(2 ** 16).fill(0xee),
+    bytes: new Uint8Array(2 ** 16).fill(0xee),
     nonce: new Uint8Array(24).fill(0xdd),
 };

--- a/tests/performance/utils.ts
+++ b/tests/performance/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Test utils.
+ *
+ * Copyright (C) 2018 Threema GmbH
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the `LICENSE.md` file for details.
+ */
+
+export const testData = {
+    plain: new Uint8Array(2 ** 16).fill(0xee),
+    nonce: new Uint8Array(24).fill(0xdd),
+};


### PR DESCRIPTION
This PR intends to improve the overall encryption/decryption performance. It also adds a performance test suite.

Results from the new tests so far are very promising. The base (*Main Thread (shared key store=false)*) is what we used before this PR.

Results are from an AMD Ryzen 7 2700X (higher % is faster).

| **Encryption**                                           | Chrome 67.0.3396.99 | Firefox 61.0.1 |
|----------------------------------------------------------|---------------------|----------------|
| **Main Thread (shared key store=false)**                     | 100% (base)         | 100% (base)    |
| Main Thread (shared key store=true)                      | 201%                | 281%           |
| Web Worker (shared key store=false, transferables=false) | 93%                 | 95%            |
| Web Worker (shared key store=false, transferables=true)  | 96%                 | 97%            |
| Web Worker (shared key store=true, transferables=false)  | 171%                | 239%           |
| Web Worker (shared key store=true, transferables=true)   | 176%                | 245%           |

| **Decryption**                                           | Chrome 67.0.3396.99 | Firefox 61.0.1 |
|----------------------------------------------------------|---------------------|----------------|
| **Main Thread (shared key store=false)**                 | 100% (base)         | 100% (base)    |
| Main Thread (shared key store=true)                      | 197%                | 275%           |
| Web Worker (shared key store=false, transferables=false) | 91%                 | 93%            |
| Web Worker (shared key store=false, transferables=true)  | 92%                 | 96%            |
| Web Worker (shared key store=true, transferables=false)  | 161%                | 235%           |
| Web Worker (shared key store=true, transferables=true)   | 174%                | 254%           |

To Do:
- [x] Use `SharedKeyStore` by default in the client
- [x] Rebase against master
- [x] Add tests for `SharedKeyStore`
- [x] ~~Update docs (need a local server for the performance tests)~~
- [x] Evaluate whether depending task implementations need to be updated to leverage `SharedKeyStore` (answer: no)