### PR TITLE
Enable int64 option for msgpack-lite

### DIFF
--- a/src/signaling/common.ts
+++ b/src/signaling/common.ts
@@ -36,10 +36,10 @@ export abstract class Signaling implements saltyrtc.Signaling {
 
     // Msgpack
     protected msgpackEncodeOptions: msgpack.EncoderOptions = {
-        codec: msgpack.createCodec({binarraybuffer: true}),
+        codec: msgpack.createCodec({binarraybuffer: true, int64: true}),
     };
     protected msgpackDecodeOptions: msgpack.DecoderOptions = {
-        codec: msgpack.createCodec({binarraybuffer: true}),
+        codec: msgpack.createCodec({binarraybuffer: true, int64: true}),
     };
 
     // Connection state


### PR DESCRIPTION
64 bit integers are now wrapped with the [int64-buffer](https://github.com/kawanet/int64-buffer) library.

To try it yourself:

```js
const data = new Uint8Array([
  131, 164, 116, 121, 112, 101, 166, 117, 112, 100, 97, 116, 101, 167, 115, 117, 98, 84, 121, 112, 101,
  174, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 73, 110, 102, 111, 164, 100, 97, 116, 97, 130,
  162, 105, 100, 196, 32, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1,
  2, 3, 4, 5, 6, 7, 8, 166, 98, 105, 103, 105, 110, 116, 207, 127, 255, 255, 255, 255, 255, 255, 247
]);
const codec = msgpack.createCodec({int64: true});
decoded = msgpack.decode(data, {codec: codec});
console.log('Object', decoded.data.bigint);
console.log('Number', +decoded.data.bigint);
console.log('String', decoded.data.bigint.toString());
```

Fixes #91.