### PR TITLE
Fix bug in CSN calculation

### DIFF
--- a/src/csn.ts
+++ b/src/csn.ts
@@ -53,8 +53,7 @@ export class CombinedSequence implements saltyrtc.CombinedSequence {
      * Warning: Do not use this for the SaltyRTC protocol itself!
      */
     public asNumber(): number {
-        // tslint:disable-next-line:no-bitwise
-        return (this.overflow << 32) | this.sequenceNumber;
+        return (this.overflow * (2 ** 32)) + this.sequenceNumber;
     }
 
 }

--- a/src/nonce.ts
+++ b/src/nonce.ts
@@ -43,15 +43,24 @@ export class Nonce {
         this._destination = destination;
     }
 
-    get cookie() { return this._cookie; }
-    get overflow() { return this._overflow; }
-    get sequenceNumber() { return this._sequenceNumber; }
-    get combinedSequenceNumber() {
-        // tslint:disable-next-line:no-bitwise
-        return (this._overflow << 32) + this._sequenceNumber;
+    get cookie() {
+        return this._cookie;
     }
-    get source() { return this._source; }
-    get destination() { return this._destination; }
+    get overflow() {
+        return this._overflow;
+    }
+    get sequenceNumber() {
+        return this._sequenceNumber;
+    }
+    get combinedSequenceNumber() {
+        return (this._overflow * (2 ** 32)) + this._sequenceNumber;
+    }
+    get source() {
+        return this._source;
+    }
+    get destination() {
+        return this._destination;
+    }
 
     /**
      * Create a signaling nonce from an ArrayBuffer.

--- a/tests/csn.spec.ts
+++ b/tests/csn.spec.ts
@@ -1,0 +1,62 @@
+// tslint:disable:file-header
+// tslint:disable:no-reference
+/// <reference path='jasmine.d.ts' />
+/// <reference path='../saltyrtc-client.d.ts' />
+
+import { CombinedSequence } from '../src/csn';
+
+export default () => { describe('csn', function() {
+
+    describe('CombinedSequence', function() {
+
+        it('constructor', () => {
+            for (let i = 0; i < 1000; i++) {
+                const csn = new CombinedSequence();
+                expect(csn.asNumber()).toBeLessThan(2 ** 32);
+                expect((csn as any).overflow).toEqual(0);
+            }
+        });
+
+        it('asNumber', () => {
+            const csn = new CombinedSequence();
+            (csn as any).sequenceNumber = 1234;
+            (csn as any).overflow = 7;
+            // (7<<32) + 1234
+            expect(csn.asNumber()).toEqual(30064772306);
+        });
+
+        it('next (overflow=0)', () => {
+            const csn = new CombinedSequence();
+            (csn as any).sequenceNumber = 1234;
+            (csn as any).overflow = 0;
+            const snapshot: saltyrtc.NextCombinedSequence = csn.next();
+            expect(snapshot.overflow).toEqual(0);
+            expect(snapshot.sequenceNumber).toEqual(1235);
+            expect((csn as any).overflow).toEqual(snapshot.overflow);
+            expect((csn as any).sequenceNumber).toEqual(snapshot.sequenceNumber);
+        });
+
+        it('next (overflow>0)', () => {
+            const csn = new CombinedSequence();
+            (csn as any).sequenceNumber = 1234;
+            (csn as any).overflow = 1337;
+            const snapshot: saltyrtc.NextCombinedSequence = csn.next();
+            expect(snapshot.overflow).toEqual(1337);
+            expect(snapshot.sequenceNumber).toEqual(1235);
+            expect((csn as any).overflow).toEqual(snapshot.overflow);
+            expect((csn as any).sequenceNumber).toEqual(snapshot.sequenceNumber);
+        });
+
+        it('next (overflow=0->1)', () => {
+            const csn = new CombinedSequence();
+            (csn as any).sequenceNumber = (2 ** 32) - 1;
+            (csn as any).overflow = 0;
+            expect((csn as any).overflow).toEqual(0);
+            expect((csn as any).sequenceNumber).toEqual(4294967295);
+            csn.next();
+            expect((csn as any).overflow).toEqual(1);
+            expect((csn as any).sequenceNumber).toEqual(0);
+        });
+    });
+
+}); };

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,22 +1,24 @@
-import "../node_modules/babel-es6-polyfill/browser-polyfill";
+import '../node_modules/babel-es6-polyfill/browser-polyfill';
 
-import test_utils from "./utils.spec";
-import test_keystore from "./keystore.spec";
-import test_nonce from "./nonce.spec";
-import test_cookie from "./cookie.spec";
-import test_eventregistry from "./eventregistry.spec";
-import test_handoverstate from "./handoverstate.spec";
-import test_client from "./client.spec";
-import test_integration from "./integration.spec";
+import test_client from './client.spec';
+import test_cookie from './cookie.spec';
+import test_csn from './csn.spec';
+import test_eventregistry from './eventregistry.spec';
+import test_handoverstate from './handoverstate.spec';
+import test_integration from './integration.spec';
+import test_keystore from './keystore.spec';
+import test_nonce from './nonce.spec';
+import test_utils from './utils.spec';
 
-var counter = 1;
+let counter = 1;
 beforeEach(() => console.info('------ TEST', counter++, 'BEGIN ------'));
 
-test_utils();
-test_keystore();
-test_nonce();
+test_client();
 test_cookie();
+test_csn();
 test_eventregistry();
 test_handoverstate();
-test_client();
 test_integration();
+test_keystore();
+test_nonce();
+test_utils();

--- a/tests/nonce.spec.ts
+++ b/tests/nonce.spec.ts
@@ -29,8 +29,8 @@ export default () => { describe('nonce', function() {
             expect(nonce.cookie.bytes).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16));
             expect(nonce.source).toEqual(17);
             expect(nonce.destination).toEqual(18);
-            expect(nonce.overflow).toEqual((1 * 2 ** 8) + 2);
-            expect(nonce.sequenceNumber).toEqual((3 * 2 ** 24) + (4 * 2 ** 16) + (5 * 2 ** 8) + 6);
+            expect(nonce.overflow).toEqual((1 * (2 ** 8)) + 2);
+            expect(nonce.sequenceNumber).toEqual((3 * (2 ** 24)) + (4 * (2 ** 16)) + (5 * (2 ** 8)) + 6);
         });
 
         it('serializes correctly', () => {
@@ -46,7 +46,7 @@ export default () => { describe('nonce', function() {
 
         it('returns the correct combined sequence number', () => {
             const nonce = Nonce.fromArrayBuffer(this.array.buffer);
-            expect(nonce.combinedSequenceNumber).toEqual((258 * 2 ** 32) + 50595078);
+            expect(nonce.combinedSequenceNumber).toEqual((258 * (2 ** 32)) + 50595078);
         });
 
     });

--- a/tests/nonce.spec.ts
+++ b/tests/nonce.spec.ts
@@ -26,12 +26,11 @@ export default () => { describe('nonce', function() {
 
         it('parses correctly', () => {
             const nonce = Nonce.fromArrayBuffer(this.array.buffer);
-            expect(nonce.cookie.bytes).toEqual(
-                Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16));
+            expect(nonce.cookie.bytes).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16));
             expect(nonce.source).toEqual(17);
             expect(nonce.destination).toEqual(18);
-            expect(nonce.overflow).toEqual((1 << 8) + 2);
-            expect(nonce.sequenceNumber).toEqual((3 << 24) + (4 << 16) + (5 << 8) + 6);
+            expect(nonce.overflow).toEqual((1 * 2 ** 8) + 2);
+            expect(nonce.sequenceNumber).toEqual((3 * 2 ** 24) + (4 * 2 ** 16) + (5 * 2 ** 8) + 6);
         });
 
         it('serializes correctly', () => {
@@ -47,7 +46,7 @@ export default () => { describe('nonce', function() {
 
         it('returns the correct combined sequence number', () => {
             const nonce = Nonce.fromArrayBuffer(this.array.buffer);
-            expect(nonce.combinedSequenceNumber).toEqual((258 << 32) + 50595078);
+            expect(nonce.combinedSequenceNumber).toEqual((258 * 2 ** 32) + 50595078);
         });
 
     });


### PR DESCRIPTION
Apparently JavaScript treats all operands in bitwise operations as 32
bit signed integers. This results in (1 << 32) being equal to 1.

This means that previously the calculation of the combined sequence
number would be wrong if the overflow number is larger than 0.git