### PR TITLE
Unbind events and add log level

### DIFF
--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -211,6 +211,7 @@ declare namespace saltyrtc {
         withKeyStore(keyStore: KeyStore): SaltyRTCBuilder;
         withTrustedPeerKey(peerTrustedKey: Uint8Array | string): SaltyRTCBuilder;
         withServerKey(serverKey: Uint8Array | string): SaltyRTCBuilder;
+        withLoggingLevel(level: saltyrtc.LogLevel): SaltyRTCBuilder;
         initiatorInfo(initiatorPublicKey: Uint8Array | string, authToken: Uint8Array | string): SaltyRTCBuilder;
         usingTasks(tasks: Task[]): SaltyRTCBuilder;
         withPingInterval(interval: number): SaltyRTCBuilder;
@@ -220,6 +221,7 @@ declare namespace saltyrtc {
     }
 
     interface SaltyRTC {
+        readonly log: saltyrtc.Log;
         state: SignalingState;
 
         keyStore: KeyStore;
@@ -302,6 +304,17 @@ declare namespace saltyrtc {
     }
 
     interface ConnectionError extends Error {
+    }
+
+    type LogLevel = 'none' | 'debug' | 'info' | 'warn' | 'error';
+
+    interface Log {
+        debug(message?: any, ...optionalParams: any[]): void;
+        trace(message?: any, ...optionalParams: any[]): void;
+        info(message?: any, ...optionalParams: any[]): void;
+        warn(message?: any, ...optionalParams: any[]): void;
+        error(message?: any, ...optionalParams: any[]): void;
+        assert(condition?: boolean, message?: string, ...data: any[]): void;
     }
 
 }
@@ -472,6 +485,10 @@ declare namespace saltyrtc.static {
         new(message: string): saltyrtc.ConnectionError;
     }
 
+    interface Log {
+        new(level: saltyrtc.LogLevel): saltyrtc.Log;
+    }
+
     /**
      * Static list of close codes.
      */
@@ -503,4 +520,5 @@ declare var saltyrtcClient: {
     explainCloseCode: (code: number) => string;
     SignalingError: saltyrtc.static.SignalingError;
     ConnectionError: saltyrtc.static.ConnectionError;
+    Log: saltyrtc.static.Log;
 };

--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -236,7 +236,7 @@ declare namespace saltyrtc {
         decryptFromPeer(box: Box): Uint8Array;
 
         connect(): void;
-        disconnect(): void;
+        disconnect(unbind?: boolean): void;
 
         sendApplicationMessage(data: any): void;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -456,10 +456,11 @@ class SaltyRTC implements saltyrtc.SaltyRTC {
      * Both the WebSocket as well as any open task connection will be closed.
      *
      * This method is asynchronous. To get notified when the connection is has
-     * been closed, subscribe to the `connection-closed` event.
+     * been closed, subscribe to the `connection-closed` event. To silence
+     * further events from the underlying connection, set `unbind` to `true`.
      */
-    public disconnect(): void {
-        this.signaling.disconnect();
+    public disconnect(unbind = false): void {
+        this.signaling.disconnect(unbind);
     }
 
     /**

--- a/src/csn.ts
+++ b/src/csn.ts
@@ -11,8 +11,6 @@ export class CombinedSequence implements saltyrtc.CombinedSequence {
     private static SEQUENCE_NUMBER_MAX = 0xFFFFFFFF; // 1<<32 - 1
     private static OVERFLOW_MAX = 0xFFFFF; // 1<<16 - 1
 
-    private logTag: string = '[SaltyRTC.CSN]';
-
     private sequenceNumber: number;
     private overflow: number;
 
@@ -34,7 +32,6 @@ export class CombinedSequence implements saltyrtc.CombinedSequence {
             this.overflow += 1;
             if (this.overflow >= CombinedSequence.OVERFLOW_MAX) {
                 // Overflow overflow
-                console.error(this.logTag, 'Overflow number just overflowed!');
                 throw new Error('overflow-overflow');
             }
         } else {

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2016-2018 Threema GmbH
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the `LICENSE.md` file for details.
+ */
+
+/**
+ * A console log wrapper obeying levels.
+ */
+export class Log implements saltyrtc.Log {
+    private _level: saltyrtc.LogLevel;
+    public debug: (message?: any, ...optionalParams: any[]) => void;
+    public trace: (message?: any, ...optionalParams: any[]) => void;
+    public info: (message?: any, ...optionalParams: any[]) => void;
+    public warn: (message?: any, ...optionalParams: any[]) => void;
+    public error: (message?: any, ...optionalParams: any[]) => void;
+    public assert: (condition?: boolean, message?: string, ...data: any[]) => void;
+
+    constructor(level: saltyrtc.LogLevel) {
+        this.level = level;
+    }
+
+    public set level(level: saltyrtc.LogLevel) {
+        // Set level
+        this._level = level;
+
+        // Reset all
+        this.debug = this.noop;
+        this.trace = this.noop;
+        this.info = this.noop;
+        this.warn = this.noop;
+        this.error = this.noop;
+        this.assert = this.noop;
+
+        // Bind corresponding to level
+        // noinspection FallThroughInSwitchStatementJS
+        switch (level) {
+            case 'debug':
+                this.debug = console.debug;
+                this.trace = console.trace;
+            case 'info':
+                this.info = console.info;
+            case 'warn':
+                this.warn = console.warn;
+            case 'error':
+                this.error = console.error;
+                this.assert = console.assert;
+            default:
+                break;
+        }
+    }
+
+    public get level(): saltyrtc.LogLevel {
+        return this._level;
+    }
+
+    private noop(): void {
+        // noop
+    }
+}

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -340,11 +340,19 @@ export default () => { describe('Integration Tests', function() {
 
         spec = it('send connection-closed event only once', async (done) => {
             console.info('===> TEST NAME:', spec.getFullName());
+            const initiator = new SaltyRTCBuilder()
+                .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withKeyStore(new KeyStore())
+                .usingTasks([new DummyTask()])
+                .withServerKey(Config.SALTYRTC_SERVER_PUBLIC_KEY)
+                .asInitiator();
             let count = 0;
-            this.initiator.on('connection-closed', (ev) => count += 1);
-            this.initiator.connect();
+            initiator.on('connection-closed', (ev) => {
+                count += 1
+            });
+            initiator.connect();
             await sleep(100);
-            this.initiator.signaling.resetConnection(3001);
+            (initiator as any).signaling.closeWebsocket(3001);
             await sleep(100);
             expect(count).toEqual(1);
             done();


### PR DESCRIPTION
These changes allow to unbind all events when disconnecting a SaltyRTC connection.

Furthermore, I've added the possibility to set a log level in the `SaltyRTCBuilder`.