### PR TITLE
Replace ArrayBuffer with Uint8Array everywhere

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -11,7 +11,7 @@ application](https://github.com/saltyrtc/saltyrtc-demo).
 To initialize a SaltyRTC client instance, you can use the `SaltyRTCBuilder`.
 
 ```javascript
-let builder = new saltyrtcClient.SaltyRTCBuilder();
+const builder = new saltyrtcClient.SaltyRTCBuilder();
 ```
 
 ### Connection Info

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saltyrtc/client",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -110,6 +110,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -248,7 +249,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1126,6 +1128,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -1173,7 +1176,8 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
       "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buildmail": {
       "version": "4.0.1",
@@ -1348,6 +1352,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1577,7 +1582,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -1736,13 +1742,15 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
       "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -2002,7 +2010,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -2167,7 +2176,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2188,12 +2198,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2208,17 +2220,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2335,7 +2350,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2347,6 +2363,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2361,6 +2378,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2368,12 +2386,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2392,6 +2412,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2472,7 +2493,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2484,6 +2506,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2569,7 +2592,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2605,6 +2629,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2624,6 +2649,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2667,12 +2693,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2926,7 +2954,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -2966,6 +2995,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -2976,6 +3006,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2999,6 +3030,7 @@
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -3008,13 +3040,15 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "https-proxy-agent": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -3025,6 +3059,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3091,7 +3126,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3366,7 +3402,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json5": {
       "version": "0.5.1",
@@ -3500,13 +3537,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -3517,7 +3556,8 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3525,7 +3565,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lodash": {
       "version": "4.17.10",
@@ -3964,13 +4005,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -4003,7 +4046,8 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -4312,7 +4356,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "private": {
       "version": "0.1.7",
@@ -4848,6 +4893,7 @@
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -5463,6 +5509,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
+      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -5478,9 +5525,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
+      "integrity": "sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==",
       "dev": true
     },
     "uglify-js": {
@@ -5517,7 +5564,8 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rollup-plugin-uglify": "^4",
     "tslint": "^5.11",
     "tweetnacl": "^1.0.0",
-    "typescript": "^2.9"
+    "typescript": "^3.3.1"
   },
   "peerDependencies": {
     "msgpack-lite": "^0.1.x",

--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -6,7 +6,6 @@
  */
 
 declare namespace saltyrtc {
-
     interface Box {
         readonly length: number;
         readonly data: Uint8Array;
@@ -62,8 +61,6 @@ declare namespace saltyrtc {
         onBoth: () => void;
         reset(): void;
     }
-
-    type SignalingChannel = 'websocket' | 'datachannel';
 
     type SignalingRole = 'initiator' | 'responder';
 
@@ -279,7 +276,6 @@ declare namespace saltyrtc {
 
     interface Cookie {
         bytes: Uint8Array;
-        asArrayBuffer(): ArrayBuffer;
         equals(otherCookie: Cookie): boolean;
     }
 
@@ -317,11 +313,9 @@ declare namespace saltyrtc {
         error(message?: any, ...optionalParams: any[]): void;
         assert(condition?: boolean, message?: string, ...data: any[]): void;
     }
-
 }
 
 declare namespace saltyrtc.messages {
-
     type MessageType = 'server-hello' | 'client-hello' | 'client-auth'
                      | 'server-auth' | 'new-initiator' | 'new-responder'
                      | 'drop-responder' | 'send-error' | 'token' | 'key'
@@ -406,11 +400,6 @@ declare namespace saltyrtc.messages {
         tasks: string[];
     }
 
-    // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#restart
-    interface Restart extends SignalingMessage {
-        type: 'restart';
-    }
-
     // https://github.com/saltyrtc/saltyrtc-meta/blob/master/Protocol.md#close-message
     interface Close extends SignalingMessage {
         type: 'close';
@@ -436,7 +425,6 @@ declare namespace saltyrtc.messages {
         type: string;
         [others: string]: any; // Make this an open interface
     }
-
 }
 
 declare namespace saltyrtc.static {
@@ -457,7 +445,6 @@ declare namespace saltyrtc.static {
     interface Cookie {
         COOKIE_LENGTH: number;
         new(bytes?: Uint8Array): saltyrtc.Cookie;
-        fromArrayBuffer(buffer: ArrayBuffer): saltyrtc.Cookie;
     }
 
     interface CookiePair {

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,7 +33,7 @@ export class SaltyRTCBuilder implements saltyrtc.SaltyRTCBuilder {
     /**
      * Validate the SaltyRTC host. Throw an `Error` if it's invalid.
      */
-    private validateHost(host: string): void {
+    private static validateHost(host: string): void {
         if (host.endsWith('/')) {
             throw new Error('SaltyRTC host may not end with a slash');
         }
@@ -86,7 +86,7 @@ export class SaltyRTCBuilder implements saltyrtc.SaltyRTCBuilder {
      * @throws Error if the host string is invalid.
      */
     public connectTo(host: string, port: number = 8765): SaltyRTCBuilder {
-        this.validateHost(host);
+        SaltyRTCBuilder.validateHost(host);
         this.host = host;
         this.port = port;
         this.hasConnectionInfo = true;

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -9,7 +9,6 @@ import * as nacl from 'tweetnacl';
 import { ProtocolError, ValidationError } from './exceptions';
 
 export class Cookie implements saltyrtc.Cookie {
-
     public static COOKIE_LENGTH = 16;
 
     public bytes: Uint8Array;
@@ -20,7 +19,7 @@ export class Cookie implements saltyrtc.Cookie {
      * If no bytes are provided, generate a random cookie.
      */
     constructor(bytes?: Uint8Array) {
-        if (typeof bytes !== 'undefined') {
+        if (bytes !== undefined) {
             if (bytes.length !== 16) {
                 throw new ValidationError('Bad cookie length');
             }
@@ -31,30 +30,13 @@ export class Cookie implements saltyrtc.Cookie {
     }
 
     /**
-     * Create a Cookie from an array.
-     */
-    public static fromArrayBuffer(buffer: ArrayBuffer): Cookie {
-        return new Cookie(new Uint8Array(buffer));
-    }
-
-    /**
-     * Return the underlying ArrayBuffer.
-     */
-    public asArrayBuffer(): ArrayBuffer {
-        return this.bytes.buffer.slice(this.bytes.byteOffset, this.bytes.byteLength);
-    }
-
-    /**
      * Return whether or not the two cookies are equal.
      */
     public equals(otherCookie: Cookie) {
         if (otherCookie.bytes === this.bytes) {
             return true;
         }
-        if (otherCookie.bytes == null || this.bytes == null) {
-            return false;
-        }
-        if (otherCookie.bytes.byteLength !== this.bytes.byteLength) {
+        if (otherCookie.bytes.byteLength !== Cookie.COOKIE_LENGTH) {
             return false;
         }
         for (let i = 0; i < this.bytes.byteLength; i++) {
@@ -64,7 +46,6 @@ export class Cookie implements saltyrtc.Cookie {
         }
         return true;
     }
-
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,7 +104,7 @@ export function concat(...arrays: Uint8Array[]): Uint8Array {
  * Wait for a condition.
  *
  * @param test a function that tests whether the condition has been met.
- * @param delay_ms wait duration between retries.
+ * @param delayMs wait duration between retries.
  * @param retries number of times to retry.
  * @param success the success callback.
  * @param error the error callback.
@@ -135,6 +135,7 @@ export function isString(value: any): value is string {
  * Validate a 32 byte key. Return the validated key as a Uint8Array instance.
  *
  * @param key Either an Uint8Array or a hex string.
+ * @param name Name of the key for the exception.
  * @throws ValidationError if key is invalid.
  */
 export function validateKey(key: Uint8Array | string, name = 'Key'): Uint8Array {
@@ -169,4 +170,18 @@ export function arraysAreEqual(a1: Uint8Array, a2: Uint8Array): boolean {
         }
     }
     return true;
+}
+
+/**
+ * Convert a TypedArray to an ArrayBuffer.
+ *
+ * **Important:** If the source array's data occupies the underlying buffer
+ *   completely, the underlying buffer will be returned directly. Thus, the
+ *   caller may not assume that the data has been copied.
+ */
+export function arrayToBuffer(array: ArrayBufferView): ArrayBuffer {
+    if (array.byteOffset === 0 && array.byteLength === array.buffer.byteLength) {
+        return array.buffer;
+    }
+    return array.buffer.slice(array.byteOffset, array.byteOffset + array.byteLength);
 }

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -163,7 +163,7 @@ export default () => { describe('client', function() {
                     .asInitiator();
             });
 
-            it('can emit events', async (done) => {
+            it('can emit events', (done: any) => {
                 this.sc.on('connected', () => {
                     expect(true).toBe(true);
                     done();
@@ -171,7 +171,7 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'connected'});
             });
 
-            it('only calls handlers for specified events', async (done) => {
+            it('only calls handlers for specified events', async (done: any) => {
                 let counter = 0;
                 this.sc.on(['connected', 'data'], () => {
                     counter += 1;
@@ -185,7 +185,7 @@ export default () => { describe('client', function() {
                 done();
             });
 
-            it('only adds a handler once', async (done) => {
+            it('only adds a handler once', async (done: any) => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.on('data', handler);
@@ -196,7 +196,7 @@ export default () => { describe('client', function() {
                 done();
             });
 
-            it('can call multiple handlers', async (done) => {
+            it('can call multiple handlers', async (done: any) => {
                 let counter = 0;
                 let handler1 = () => {counter += 1;};
                 let handler2 = () => {counter += 1;};
@@ -209,7 +209,7 @@ export default () => { describe('client', function() {
                 done();
             });
 
-            it('can cancel handlers', async (done) => {
+            it('can cancel handlers', async (done: any) => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.on(['data', 'connected'], handler);
@@ -223,7 +223,7 @@ export default () => { describe('client', function() {
                 done();
             });
 
-            it('can cancel handlers for multiple events', async (done) => {
+            it('can cancel handlers for multiple events', async (done: any) => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.on(['data', 'connected'], handler);
@@ -237,7 +237,7 @@ export default () => { describe('client', function() {
                 done();
             });
 
-            it('can register one-time handlers', async (done) => {
+            it('can register one-time handlers', async (done: any) => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.once('data', handler);
@@ -248,7 +248,7 @@ export default () => { describe('client', function() {
                 done();
             });
 
-            it('can register one-time handlers that throw', async (done) => {
+            it('can register one-time handlers that throw', async (done: any) => {
                 let counter = 0;
                 let handler = () => {counter += 1; throw 'oh noes';};
                 this.sc.once('data', handler);
@@ -259,7 +259,7 @@ export default () => { describe('client', function() {
                 done();
             });
 
-            it('removes handlers that return false', async (done) => {
+            it('removes handlers that return false', async (done: any) => {
                 let counter = 0;
                 let handler = () => {
                     if (counter <= 4) {

--- a/tests/eventregistry.spec.ts
+++ b/tests/eventregistry.spec.ts
@@ -11,8 +11,8 @@ export default () => { describe('eventregistry', function() {
 
         beforeEach(() => {
             this.registry = new EventRegistry();
-            this.handler1 = (ev: saltyrtc.SaltyRTCEvent) => { console.log('Event 1 occurred'); };
-            this.handler2 = (ev: saltyrtc.SaltyRTCEvent) => { console.log('Event 2 occurred'); };
+            this.handler1 = () => { console.log('Event 1 occurred'); };
+            this.handler2 = () => { console.log('Event 2 occurred'); };
         });
 
         it('can register a new event', () => {
@@ -58,7 +58,7 @@ export default () => { describe('eventregistry', function() {
             this.registry.map.set('far', [this.handler1, this.handler2]);
 
             // Unknown handler
-            this.registry.unregister('far', (ev: saltyrtc.SaltyRTCEvent) => { /* do nothing */ });
+            this.registry.unregister('far', () => { /* do nothing */ });
             expect(this.registry.get('far')).toEqual([this.handler1, this.handler2]);
 
             // Unknown event

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -37,7 +37,7 @@ export default () => { describe('Integration Tests', function() {
             .asResponder() as saltyrtc.SaltyRTC;
 
         // Helper function. Connect both clients and resolve once they both finished the peer handshake.
-        this.connectBoth = (a, b) => {
+        this.connectBoth = (a: saltyrtc.SaltyRTC, b: saltyrtc.SaltyRTC) => {
             let ready = 0;
             return new Promise((resolve) => {
                 const handler = () => { if (++ready == 2) resolve() };
@@ -51,7 +51,7 @@ export default () => { describe('Integration Tests', function() {
 
     describe('SaltyRTC', () => {
 
-        spec = it('connect (initiator first)', async (done) => {
+        spec = it('connect (initiator first)', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
@@ -68,7 +68,7 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('connect (responder first)', async (done) => {
+        spec = it('connect (responder first)', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
@@ -85,18 +85,18 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('connect speed', async (done) => {
+        spec = it('connect speed', (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
-            let t1;
+            let t1: Date;
             let t2;
             let ready = 0;
             const callback = () => {
                 ready += 1;
                 if (ready === 2) {
                     t2 = new Date();
-                    const diffMs = t2 - t1;
+                    const diffMs = t2.valueOf() - t1.valueOf();
                     console.info('Full handshake took', diffMs, 'milliseconds');
                     expect(diffMs).toBeLessThan(1000);
                     done();
@@ -109,7 +109,7 @@ export default () => { describe('Integration Tests', function() {
             this.responder.connect();
         });
 
-        spec = it('disconnect before peer handshake', async (done) => {
+        spec = it('disconnect before peer handshake', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
@@ -125,7 +125,7 @@ export default () => { describe('Integration Tests', function() {
             this.initiator.disconnect();
         });
 
-        spec = it('disconnect after peer handshake', async (done) => {
+        spec = it('disconnect after peer handshake', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
@@ -138,7 +138,7 @@ export default () => { describe('Integration Tests', function() {
             this.initiator.disconnect();
         });
 
-        spec = it('new-responder event (responder first)', async (done) => {
+        spec = it('new-responder event (responder first)', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
@@ -163,9 +163,9 @@ export default () => { describe('Integration Tests', function() {
 
             // Register event handler
             let eventCounter = 0;
-            this.initiator.on('new-responder', (ev) => eventCounter += 1);
-            responder1.on('new-responder', (id) => done.fail());
-            responder2.on('new-responder', (id) => done.fail());
+            this.initiator.on('new-responder', () => eventCounter += 1);
+            responder1.on('new-responder', () => done.fail());
+            responder2.on('new-responder', () => done.fail());
 
             // Connect responders
             responder1.connect();
@@ -181,15 +181,15 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('new-responder event (initiator first)', async (done) => {
+        spec = it('new-responder event (initiator first)', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
 
             // Register event handler
             let eventCounter = 0;
-            this.initiator.on('new-responder', (ev) => eventCounter += 1);
-            this.responder.on('new-responder', (id) => done.fail());
+            this.initiator.on('new-responder', () => eventCounter += 1);
+            this.responder.on('new-responder', () => done.fail());
 
             // Connect initiator
             this.initiator.connect();
@@ -204,7 +204,7 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('getting peer permanent key', async (done) => {
+        spec = it('getting peer permanent key', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             await this.connectBoth(this.initiator, this.responder);
             expect(this.initiator.peerPermanentKeyBytes).toEqual(this.responder.permanentKeyBytes);
@@ -214,7 +214,7 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('using trusted keys to connect', async (done) => {
+        spec = it('using trusted keys to connect', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             // Generate keys
             const oldInitiator = new SaltyRTCBuilder()
@@ -255,7 +255,7 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('validate server auth success (initiator)', async (done) => {
+        spec = it('validate server auth success (initiator)', (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
@@ -268,7 +268,7 @@ export default () => { describe('Integration Tests', function() {
             initiator.once('state-change:peer-handshake', done);
         });
 
-        spec = it('validate server auth validation fail (initiator)', async (done) => {
+        spec = it('validate server auth validation fail (initiator)', (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
@@ -286,7 +286,7 @@ export default () => { describe('Integration Tests', function() {
             });
         });
 
-        spec = it('validate server auth success (responder)', async (done) => {
+        spec = it('validate server auth success (responder)', (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
@@ -300,10 +300,10 @@ export default () => { describe('Integration Tests', function() {
             responder.once('state-change:peer-handshake', done);
         });
 
-        spec = it('connect dynamically using factory function', async (done) => {
+        spec = it('connect dynamically using factory function', (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             const responder = new SaltyRTCBuilder()
-                .connectWith((initiatorPublicKeyHex: string) => {
+                .connectWith(() => {
                     return {
                         host: Config.SALTYRTC_HOST,
                         port: Config.SALTYRTC_PORT,
@@ -319,7 +319,7 @@ export default () => { describe('Integration Tests', function() {
             responder.once('state-change:peer-handshake', done);
         });
 
-        spec = it('validate server auth validation fail (responder)', async (done) => {
+        spec = it('validate server auth validation fail (responder)', (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
@@ -338,7 +338,7 @@ export default () => { describe('Integration Tests', function() {
             });
         });
 
-        spec = it('send connection-closed event only once', async (done) => {
+        spec = it('send connection-closed event only once', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
@@ -347,7 +347,7 @@ export default () => { describe('Integration Tests', function() {
                 .withServerKey(Config.SALTYRTC_SERVER_PUBLIC_KEY)
                 .asInitiator();
             let count = 0;
-            initiator.on('connection-closed', (ev) => {
+            initiator.on('connection-closed', () => {
                 count += 1
             });
             initiator.connect();
@@ -358,7 +358,7 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('can send application messages', async (done) => {
+        spec = it('can send application messages', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             await this.connectBoth(this.initiator, this.responder);
             expect(this.initiator.state).toEqual('task');
@@ -376,7 +376,7 @@ export default () => { describe('Integration Tests', function() {
 
         const slowdescribe = Config.RUN_LOAD_TESTS ? describe : xdescribe;
         slowdescribe('slow load tests', () => {
-            let originalTimeout;
+            let originalTimeout: number;
             beforeEach(function() {
                 originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
                 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
@@ -391,7 +391,7 @@ export default () => { describe('Integration Tests', function() {
              * - Firefox: about:config -> network.websocket.max-connections
              * - Chrome: Not possible.
              */
-            spec = it('drops inactive responders when the path gets full', async (done) => {
+            spec = it('drops inactive responders when the path gets full', async (done: any) => {
                 console.info('===> TEST NAME:', spec.getFullName());
                 this.initiator.connect();
                 await new Promise((resolve) => this.initiator.once('state-change:peer-handshake', resolve));
@@ -448,7 +448,7 @@ export default () => { describe('Integration Tests', function() {
     });
 
     describe('Tasks', () => {
-        spec = it('can send a ping pong task message', async (done) => {
+        spec = it('can send a ping pong task message', async (done: any) => {
             console.info('===> TEST NAME:', spec.getFullName());
             // Create peers
             const initiator = new SaltyRTCBuilder()

--- a/tests/nonce.spec.ts
+++ b/tests/nonce.spec.ts
@@ -25,11 +25,11 @@ export default () => { describe('nonce', function() {
         });
 
         it('parses correctly', () => {
-            const nonce = Nonce.fromArrayBuffer(this.array.buffer);
+            const nonce = Nonce.fromUint8Array(this.array);
             expect(nonce.cookie.bytes).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16));
             expect(nonce.source).toEqual(17);
             expect(nonce.destination).toEqual(18);
-            expect(nonce.overflow).toEqual((1 * (2 ** 8)) + 2);
+            expect(nonce.overflow).toEqual((2 ** 8) + 2);
             expect(nonce.sequenceNumber).toEqual((3 * (2 ** 24)) + (4 * (2 ** 16)) + (5 * (2 ** 8)) + 6);
         });
 
@@ -40,12 +40,11 @@ export default () => { describe('nonce', function() {
             const overflow = 258;
             const sequenceNumber = 50595078;
             const nonce = new Nonce(cookie, overflow, sequenceNumber, source, destination);
-            const buf = nonce.toArrayBuffer();
-            expect(new Uint8Array(buf)).toEqual(this.array);
+            expect(nonce.toUint8Array()).toEqual(this.array);
         });
 
         it('returns the correct combined sequence number', () => {
-            const nonce = Nonce.fromArrayBuffer(this.array.buffer);
+            const nonce = Nonce.fromUint8Array(this.array);
             expect(nonce.combinedSequenceNumber).toEqual((258 * (2 ** 32)) + 50595078);
         });
 

--- a/tests/performance/crypto.spec.ts
+++ b/tests/performance/crypto.spec.ts
@@ -71,8 +71,7 @@ export default () => {
         [false, true].forEach((useSharedKeyStore) => {
             describe(`Web Worker (shared key store=${useSharedKeyStore}, transferables=false)`, () => {
                 it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
-                    // @ts-ignore
-                    expect(window.Worker).toBeDefined();
+                    expect(Worker).toBeDefined();
                     const worker = new Worker('performance/crypto.worker.js');
                     let iterations = 0;
                     worker.onmessage = () => {
@@ -106,8 +105,7 @@ export default () => {
                 }, 30000);
 
                 it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
-                    // @ts-ignore
-                    expect(window.Worker).toBeDefined();
+                    expect(Worker).toBeDefined();
                     const worker = new Worker('performance/crypto.worker.js');
                     let iterations = 0;
                     worker.onmessage = () => {
@@ -145,8 +143,7 @@ export default () => {
 
             describe(`Web Worker (shared key store=${useSharedKeyStore}, transferables=true)`, () => {
                 it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
-                    // @ts-ignore
-                    expect(window.Worker).toBeDefined();
+                    expect(Worker).toBeDefined();
 
                     const worker = new Worker('performance/crypto.worker.js');
                     let iterations = 0;
@@ -188,8 +185,7 @@ export default () => {
                 }, 60000);
 
                 it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
-                    // @ts-ignore
-                    expect(window.Worker).toBeDefined();
+                    expect(Worker).toBeDefined();
 
                     const worker = new Worker('performance/crypto.worker.js');
                     let iterations = 0;

--- a/tests/performance/crypto.spec.ts
+++ b/tests/performance/crypto.spec.ts
@@ -70,7 +70,8 @@ export default () => {
 
         [false, true].forEach((useSharedKeyStore) => {
             describe(`Web Worker (shared key store=${useSharedKeyStore}, transferables=false)`, () => {
-                it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
+                    // @ts-ignore
                     expect(window.Worker).toBeDefined();
                     const worker = new Worker('performance/crypto.worker.js');
                     let iterations = 0;
@@ -104,7 +105,8 @@ export default () => {
                     }
                 }, 30000);
 
-                it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
+                    // @ts-ignore
                     expect(window.Worker).toBeDefined();
                     const worker = new Worker('performance/crypto.worker.js');
                     let iterations = 0;
@@ -142,7 +144,8 @@ export default () => {
             });
 
             describe(`Web Worker (shared key store=${useSharedKeyStore}, transferables=true)`, () => {
-                it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                it(`encrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
+                    // @ts-ignore
                     expect(window.Worker).toBeDefined();
 
                     const worker = new Worker('performance/crypto.worker.js');
@@ -184,7 +187,8 @@ export default () => {
                     }
                 }, 60000);
 
-                it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done) => {
+                it(`decrypt ${Config.CRYPTO_ITERATIONS} times`, (done: any) => {
+                    // @ts-ignore
                     expect(window.Worker).toBeDefined();
 
                     const worker = new Worker('performance/crypto.worker.js');

--- a/tests/testtasks.ts
+++ b/tests/testtasks.ts
@@ -7,7 +7,7 @@ export class DummyTask implements saltyrtc.Task {
     protected signaling: saltyrtc.Signaling;
     protected name: string;
 
-    constructor(name?: string) {
+    public constructor(name?: string) {
         if (name === undefined) {
             this.name = 'dummy.tasks.saltyrtc.org';
         } else {
@@ -15,36 +15,38 @@ export class DummyTask implements saltyrtc.Task {
         }
     }
 
-    init(signaling: saltyrtc.Signaling, data: object): void {
+    public init(signaling: saltyrtc.Signaling, data: object): void {
         this.signaling = signaling;
         this.peerData = data;
         this.initialized = true;
     }
 
-    onPeerHandshakeDone(): void {
+    public onPeerHandshakeDone(): void {
     }
 
-    onTaskMessage(message: saltyrtc.messages.TaskMessage): void {
+    public onTaskMessage(message: saltyrtc.messages.TaskMessage): void {
         console.log("Got new task message");
     }
 
-    sendSignalingMessage(payload: Uint8Array) {
+    // noinspection JSMethodCanBeStatic
+    public sendSignalingMessage(payload: Uint8Array) {
         console.log("Sending signaling message (" + payload.byteLength + " bytes)");
     }
 
-    getName(): string {
+    public getName(): string {
         return this.name;
     }
 
-    getSupportedMessageTypes(): string[] {
+    public getSupportedMessageTypes(): string[] {
         return ['dummy'];
     }
 
-    getData(): object {
+    // noinspection JSMethodCanBeStatic
+    public getData(): object {
         return {};
     }
 
-    close(reason: number): void {
+    public close(): void {
         // Do nothing
     }
 
@@ -55,32 +57,32 @@ export class PingPongTask extends DummyTask {
     public sentPong = false;
     public receivedPong = false;
 
-    constructor() {
+    public constructor() {
         super('pingpong.tasks.saltyrtc.org');
     }
 
-    getSupportedMessageTypes(): string[] {
+    public getSupportedMessageTypes(): string[] {
         return ['ping', 'pong'];
     }
 
-    onPeerHandshakeDone(): void {
+    public onPeerHandshakeDone(): void {
         if (this.signaling.role == 'initiator') {
             this.sendPing();
         }
     }
 
-    sendPing(): void {
+    public sendPing(): void {
         console.log('[PingPongTask] Sending ping');
         this.signaling.sendTaskMessage({'type': 'ping'});
     }
 
-    sendPong(): void {
+    public sendPong(): void {
         console.log('[PingPongTask] Sending pong');
         this.signaling.sendTaskMessage({'type': 'pong'});
         this.sentPong = true;
     }
 
-    onTaskMessage(message: saltyrtc.messages.TaskMessage): void {
+    public onTaskMessage(message: saltyrtc.messages.TaskMessage): void {
         if (message.type === 'ping') {
             console.log('[PingPongTask] Received ping');
             this.sendPong();

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -111,7 +111,7 @@ export default () => { describe('utils', function() {
 
     describe('waitFor', function() {
 
-        it('retries until the condition is met', async (done) => {
+        it('retries until the condition is met', (done: any) => {
             let i = 3;
             // To test, this condition has a side effect.
             // It will return true the 4th time it is called.
@@ -125,7 +125,7 @@ export default () => { describe('utils', function() {
             }, done.fail);
         });
 
-        it('fails if the condition is not met', async (done) => {
+        it('fails if the condition is not met', (done: any) => {
             let tries = 0;
             const test = () => {
                 tries += 1;
@@ -143,6 +143,7 @@ export default () => { describe('utils', function() {
         it('detects strings', () => {
             expect(isString('hello')).toEqual(true);
             // tslint:disable-next-line:no-construct
+            // noinspection JSPrimitiveTypeWrapperUsage
             expect(isString(new String('hello'))).toEqual(true);
             expect(isString(String)).toEqual(false);
             expect(isString(1232)).toEqual(false);


### PR DESCRIPTION
This simplifies the code a bit, reduces the amount of copies and
allows us to consistently use `Uint8Array` everywhere.

Further changes:

- Removed dead code
- Removed obsolete methods
- More code cleanup
- Update docs