### PR TITLE
Expose all exceptions for construction

### DIFF
--- a/saltyrtc-client.d.ts
+++ b/saltyrtc-client.d.ts
@@ -6,6 +6,24 @@
  */
 
 declare namespace saltyrtc {
+    type CryptoErrorCode = 'bad-message-length' | 'bad-token-length' | 'decryption-failed'
+
+    interface SignalingError extends Error {
+        readonly closeCode: number;
+    }
+
+    interface ProtocolError extends SignalingError {}
+
+    interface ConnectionError extends Error {}
+
+    interface ValidationError extends Error {
+        readonly critical: boolean;
+    }
+
+    interface CryptoError extends Error {
+        readonly code: CryptoErrorCode;
+    }
+
     interface Box {
         readonly length: number;
         readonly data: Uint8Array;
@@ -295,13 +313,6 @@ declare namespace saltyrtc {
         theirs: number;
     }
 
-    interface SignalingError extends Error {
-        closeCode: number;
-    }
-
-    interface ConnectionError extends Error {
-    }
-
     type LogLevel = 'none' | 'debug' | 'info' | 'warn' | 'error';
 
     interface Log {
@@ -428,6 +439,25 @@ declare namespace saltyrtc.messages {
 }
 
 declare namespace saltyrtc.static {
+    interface SignalingError {
+        new(closeCode: number, message: string): saltyrtc.SignalingError;
+    }
+
+    interface ProtocolError {
+        new(message: string): saltyrtc.ProtocolError;
+    }
+
+    interface ConnectionError {
+        new(message: string): saltyrtc.ConnectionError;
+    }
+
+    interface ValidationError {
+        new(message: string, critical?: boolean): saltyrtc.ValidationError;
+    }
+
+    interface CryptoError {
+        new(code: CryptoErrorCode, message: string): saltyrtc.CryptoError;
+    }
 
     interface SaltyRTCBuilder {
         new(): saltyrtc.SaltyRTCBuilder;
@@ -465,14 +495,6 @@ declare namespace saltyrtc.static {
         new(): saltyrtc.EventRegistry;
     }
 
-    interface SignalingError {
-        new(closeCode: number, message: string): saltyrtc.SignalingError;
-    }
-
-    interface ConnectionError {
-        new(message: string): saltyrtc.ConnectionError;
-    }
-
     interface Log {
         new(level: saltyrtc.LogLevel): saltyrtc.Log;
     }
@@ -496,6 +518,13 @@ declare namespace saltyrtc.static {
 }
 
 declare var saltyrtcClient: {
+    exceptions: {
+        SignalingError: saltyrtc.static.SignalingError,
+        ProtocolError: saltyrtc.static.ProtocolError,
+        ConnectionError: saltyrtc.static.ConnectionError,
+        ValidationError: saltyrtc.static.ValidationError,
+        CryptoError: saltyrtc.static.CryptoError,
+    },
     SaltyRTCBuilder: saltyrtc.static.SaltyRTCBuilder;
     KeyStore: saltyrtc.static.KeyStore;
     Box: saltyrtc.static.Box;

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -12,8 +12,8 @@ import { CloseCode } from './closecode';
  *
  * It will result in the connection closing with the specified error code.
  */
-export class SignalingError extends Error {
-    public closeCode: number;
+export class SignalingError extends Error implements saltyrtc.SignalingError {
+    public readonly closeCode: number;
     constructor(closeCode: number, message: string) {
         super(message);
         this.message = message;
@@ -25,7 +25,7 @@ export class SignalingError extends Error {
 /**
  * A signaling error with the close code hardcoded to ProtocolError.
  */
-export class ProtocolError extends SignalingError {
+export class ProtocolError extends SignalingError implements saltyrtc.ProtocolError {
     constructor(message: string) {
         super(CloseCode.ProtocolError, message);
     }
@@ -34,7 +34,7 @@ export class ProtocolError extends SignalingError {
 /**
  * Errors related to the network connection state.
  */
-export class ConnectionError extends Error {
+export class ConnectionError extends Error implements saltyrtc.ConnectionError {
     constructor(message: string) {
         super(message);
         this.message = message;
@@ -45,10 +45,10 @@ export class ConnectionError extends Error {
 /**
  * Errors related to validation.
  */
-export class ValidationError extends Error {
+export class ValidationError extends Error implements saltyrtc.ValidationError {
     // If this flag is set, then the validation error
     // will be converted to a protocol error.
-    public critical: boolean;
+    public readonly critical: boolean;
 
     constructor(message: string, critical: boolean = true) {
         super(message);
@@ -61,19 +61,15 @@ export class ValidationError extends Error {
 /**
  * Crypto related errors.
  */
-export class CryptoError extends Error {
+export class CryptoError extends Error implements saltyrtc.CryptoError {
     // A short string used to identify the exception
     // independently from the error message.
-    private _code: string;
+    public readonly code: saltyrtc.CryptoErrorCode;
 
-    constructor(code: string, message: string) {
+    constructor(code: saltyrtc.CryptoErrorCode, message: string) {
         super(message);
         this.name = 'CryptoError';
         this.message = message;
-        this._code = code;
-    }
-
-    public get code(): string {
-        return this._code;
+        this.code = code;
     }
 }


### PR DESCRIPTION
It can be necessary for tasks to construct and throw these. One example being the WebRTC task with the new proposed API.