### PR TITLE
Fix protocol errors triggered by new clients after task state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,61 +1,81 @@
 version: 2
 
-references:
-  docker-config: &docker-config
-      - image: quay.io/saltyrtc/circleci-image-js:latest
-        environment:
-          FIREFOX_BIN: xvfb-firefox
 
-jobs:
-  test:
-    docker: *docker-config
+shared:
+  lint: &lint-config
     steps:
       - checkout
 
       # Install dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
       - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # Run linter
+      - run:
+          name: Run linter
+          command: npm run lint
+
+  test: &test-config
+    steps:
+      - checkout
+
+      # Install dependencies
+      - run: npm install
 
       # Start SaltyRTC server
       - run: saltyrtc-server-launcher > /saltyrtc/server.pid && sleep 2
 
+      # Show browser version
+      - run: if which firefox >/dev/null; then firefox --version; fi
+      - run: if which chrome >/dev/null; then chrome --version; fi
+      - run: if which chromium >/dev/null; then chromium --version; fi
+
       # Run tests
-      - run: npm run rollup_tests && npm test
-      - run: node_modules/.bin/tsc --noEmit
+      - run:
+          name: Run tests
+          command: npm run rollup_tests && npm test -- --browsers $BROWSER
+      - run:
+          name: Run type checks
+          command: node_modules/.bin/tsc --noEmit
 
       # Stop SaltyRTC server
       - run: kill -INT $(cat /saltyrtc/server.pid)
+
+
+jobs:
   lint:
-    docker: *docker-config
-    steps:
-      - checkout
+    <<: *lint-config
+    docker:
+      - image: circleci/node:10-browsers
 
-      # Install dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-      - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+  test-chromium-latest:
+    <<: *test-config
+    docker:
+      - image: saltyrtc/circleci-image-js:chromium-latest
+    environment:
+      - BROWSER: ChromiumHeadless
 
-      # Run linter
-      - run: npm run lint
+  test-firefox-stable:
+    <<: *test-config
+    docker:
+      - image: saltyrtc/circleci-image-js:firefox-60.6.3esr
+    environment:
+      BROWSER: Firefox_circle_ci
+      FIREFOX_BIN: xvfb-firefox
+
+  test-firefox-esr:
+    <<: *test-config
+    docker:
+      - image: saltyrtc/circleci-image-js:firefox-66.0.5
+    environment:
+      BROWSER: Firefox_circle_ci
+      FIREFOX_BIN: xvfb-firefox
+
 
 workflows:
   version: 2
   build:
     jobs:
-      - test
       - lint
+      - test-chromium-latest
+      - test-firefox-stable
+      - test-firefox-esr

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,26 +1,26 @@
 module.exports = function(config) {
 
-  var configuration = {
-    frameworks: ['jasmine'],
-    files: [
-      'node_modules/tweetnacl/nacl-fast.min.js',
-      'node_modules/msgpack-lite/dist/msgpack.min.js',
-      'tests/testsuite.js'
-    ],
-    customLaunchers: {
-      Firefox_circle_ci: {
-        base: 'Firefox',
-        profile: '/home/ci/.mozilla/firefox/saltyrtc',
-      }
+    const configuration = {
+        frameworks: ['jasmine'],
+            files: [
+                'node_modules/tweetnacl/nacl-fast.min.js',
+                'node_modules/msgpack-lite/dist/msgpack.min.js',
+                'tests/testsuite.js'
+            ],
+        customLaunchers: {
+            Firefox_circle_ci: {
+                base: 'Firefox',
+                profile: '/home/ci/.mozilla/firefox/saltyrtc',
+            }
+        }
+    };
+
+    if (process.env.CIRCLECI) {
+        configuration.browsers = ['ChromiumHeadless', 'Firefox_circle_ci'];
+    } else {
+        configuration.browsers = ['Chromium', 'Firefox'];
     }
-  };
 
-  if (process.env.CIRCLECI) {
-    configuration.browsers = ['ChromiumHeadless', 'Firefox_circle_ci'];
-  } else {
-    configuration.browsers = ['Chromium', 'Firefox'];
-  }
+    config.set(configuration);
 
-  config.set(configuration);
-
-}
+};

--- a/src/signaling/initiator.ts
+++ b/src/signaling/initiator.ts
@@ -303,6 +303,27 @@ export class InitiatorSignaling extends Signaling {
         }
     }
 
+    /**
+     * Drop a new responder after a handshake with one responder has already
+     * completed.
+     *
+     * Note: This deviates from the intention of the specification to allow
+     *       for more than one connection towards a responder over the same
+     *       WebSocket connection.
+     */
+    protected onUnhandledSignalingServerMessage(msg: saltyrtc.Message): void {
+        if (msg.type === 'new-responder') {
+            try {
+                this.log.debug(this.logTag, 'Received new-responder');
+                this.handleNewResponder(msg as saltyrtc.messages.NewResponder);
+            } catch (error) {
+                this.log.warn(this.logTag, 'Ignoring invalid new-responder message');
+            }
+        } else {
+            this.log.warn(this.logTag, 'Unknown server message type:', msg.type);
+        }
+    }
+
     protected sendClientHello(): void {
         // No-op as initiator.
     }
@@ -353,8 +374,13 @@ export class InitiatorSignaling extends Signaling {
             throw new ProtocolError('Responder id ' + msg.id + ' must be in the range 0x02-0xff');
         }
 
-        // Process responder
-        this.processNewResponder(msg.id);
+        // Process or ignore responder
+        if (this.state === 'peer-handshake') {
+            this.processNewResponder(msg.id);
+        } else {
+            this.log.debug(this.logTag, `Dropping responder ${msg.id} in '${this.state}' state`);
+            this.dropResponder(msg.id, CloseCode.DroppedByInitiator);
+        }
     }
 
     /**

--- a/src/signaling/initiator.ts
+++ b/src/signaling/initiator.ts
@@ -117,8 +117,10 @@ export class InitiatorSignaling extends Signaling {
      * @throws SignalingError
      */
     protected processNewResponder(responderId: number): void {
-        // Drop responder if it's already known
+        // Discard previous responder (if any)
         if (this.responders.has(responderId)) {
+            this.log.warn(this.logTag, 'Previous responder discarded (server ' +
+                `should have sent 'disconnected' message): ${responderId}`);
             this.responders.delete(responderId);
         }
 

--- a/src/signaling/initiator.ts
+++ b/src/signaling/initiator.ts
@@ -194,7 +194,7 @@ export class InitiatorSignaling extends Signaling {
             const msg: saltyrtc.Message = this.decodeMessage(payload, 'server');
             switch (msg.type) {
                 case 'new-responder':
-                    this.log.debug(this.logTag, 'Received new-responder',
+                    this.log.debug(this.logTag, 'Received new-responder message',
                         byteToHex((msg as saltyrtc.messages.NewResponder).id));
                     this.handleNewResponder(msg as saltyrtc.messages.NewResponder);
                     break;
@@ -314,7 +314,7 @@ export class InitiatorSignaling extends Signaling {
     protected onUnhandledSignalingServerMessage(msg: saltyrtc.Message): void {
         if (msg.type === 'new-responder') {
             try {
-                this.log.debug(this.logTag, 'Received new-responder');
+                this.log.debug(this.logTag, 'Received new-responder message');
                 this.handleNewResponder(msg as saltyrtc.messages.NewResponder);
             } catch (error) {
                 this.log.warn(this.logTag, 'Ignoring invalid new-responder message');

--- a/src/signaling/responder.ts
+++ b/src/signaling/responder.ts
@@ -125,7 +125,7 @@ export class ResponderSignaling extends Signaling {
             const msg: saltyrtc.Message = this.decodeMessage(payload, 'server');
             switch (msg.type) {
                 case 'new-initiator':
-                    this.log.debug(this.logTag, 'Received new-initiator');
+                    this.log.debug(this.logTag, 'Received new-initiator message');
                     this.handleNewInitiator();
                     break;
                 case 'send-error':
@@ -230,7 +230,7 @@ export class ResponderSignaling extends Signaling {
      */
     protected onUnhandledSignalingServerMessage(msg: saltyrtc.Message): void {
         if (msg.type === 'new-initiator') {
-            this.log.debug(this.logTag, 'Received new-initiator after peer handshake completed, ' +
+            this.log.debug(this.logTag, 'Received new-initiator message after peer handshake completed, ' +
                 'closing');
             this.resetConnection(CloseCode.ClosingNormal);
         } else {

--- a/src/signaling/responder.ts
+++ b/src/signaling/responder.ts
@@ -221,6 +221,23 @@ export class ResponderSignaling extends Signaling {
         }
     }
 
+    /**
+     * Close when a new initiator has connected.
+     *
+     * Note: This deviates from the intention of the specification to allow
+     *       for more than one connection towards an initiator over the same
+     *       WebSocket connection.
+     */
+    protected onUnhandledSignalingServerMessage(msg: saltyrtc.Message): void {
+        if (msg.type === 'new-initiator') {
+            this.log.debug(this.logTag, 'Received new-initiator after peer handshake completed, ' +
+                'closing');
+            this.resetConnection(CloseCode.ClosingNormal);
+        } else {
+            this.log.warn(this.logTag, 'Unknown server message type:', msg.type);
+        }
+    }
+
     protected sendClientHello(): void {
         const message: saltyrtc.messages.ClientHello = {
             type: 'client-hello',

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -171,7 +171,7 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'connected'});
             });
 
-            it('only calls handlers for specified events', async (done: any) => {
+            it('only calls handlers for specified events', async () => {
                 let counter = 0;
                 this.sc.on(['connected', 'data'], () => {
                     counter += 1;
@@ -182,10 +182,9 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'connected'});
                 await sleep(20);
                 expect(counter).toEqual(3);
-                done();
             });
 
-            it('only adds a handler once', async (done: any) => {
+            it('only adds a handler once', async () => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.on('data', handler);
@@ -193,10 +192,9 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'data'});
                 await sleep(20);
                 expect(counter).toEqual(1);
-                done();
             });
 
-            it('can call multiple handlers', async (done: any) => {
+            it('can call multiple handlers', async () => {
                 let counter = 0;
                 let handler1 = () => {counter += 1;};
                 let handler2 = () => {counter += 1;};
@@ -206,10 +204,9 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'data'});
                 await sleep(20);
                 expect(counter).toEqual(3);
-                done();
             });
 
-            it('can cancel handlers', async (done: any) => {
+            it('can cancel handlers', async () => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.on(['data', 'connected'], handler);
@@ -220,10 +217,9 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'data'});
                 await sleep(20);
                 expect(counter).toEqual(3);
-                done();
             });
 
-            it('can cancel handlers for multiple events', async (done: any) => {
+            it('can cancel handlers for multiple events', async () => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.on(['data', 'connected'], handler);
@@ -234,10 +230,9 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'data'});
                 await sleep(20);
                 expect(counter).toEqual(2);
-                done();
             });
 
-            it('can register one-time handlers', async (done: any) => {
+            it('can register one-time handlers', async () => {
                 let counter = 0;
                 let handler = () => {counter += 1;};
                 this.sc.once('data', handler);
@@ -245,10 +240,9 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'data'});
                 await sleep(20);
                 expect(counter).toEqual(1);
-                done();
             });
 
-            it('can register one-time handlers that throw', async (done: any) => {
+            it('can register one-time handlers that throw', async () => {
                 let counter = 0;
                 let handler = () => {counter += 1; throw 'oh noes';};
                 this.sc.once('data', handler);
@@ -256,10 +250,9 @@ export default () => { describe('client', function() {
                 this.sc.emit({type: 'data'});
                 await sleep(20);
                 expect(counter).toEqual(1);
-                done();
             });
 
-            it('removes handlers that return false', async (done: any) => {
+            it('removes handlers that return false', async () => {
                 let counter = 0;
                 let handler = () => {
                     if (counter <= 4) {
@@ -274,7 +267,6 @@ export default () => { describe('client', function() {
                 }
                 await sleep(20);
                 expect(counter).toEqual(5);
-                done();
             });
 
         });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -23,6 +23,7 @@ export default () => { describe('Integration Tests', function() {
     beforeEach(() => {
         this.initiator = new SaltyRTCBuilder()
             .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+            .withLoggingLevel('warn')
             .withKeyStore(new KeyStore())
             .usingTasks([new DummyTask()])
             .asInitiator() as saltyrtc.SaltyRTC;
@@ -31,6 +32,7 @@ export default () => { describe('Integration Tests', function() {
         const authToken = this.initiator.authTokenBytes;
         this.responder = new SaltyRTCBuilder()
             .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+            .withLoggingLevel('warn')
             .withKeyStore(new KeyStore())
             .initiatorInfo(pubKey, authToken)
             .usingTasks([new DummyTask()])
@@ -148,12 +150,14 @@ export default () => { describe('Integration Tests', function() {
             const authToken = this.initiator.authTokenBytes;
             const responder1 = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .initiatorInfo(pubKey, authToken)
                 .usingTasks([new DummyTask()])
                 .asResponder();
             const responder2 = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .initiatorInfo(pubKey, authToken)
                 .usingTasks([new DummyTask()])
@@ -219,11 +223,13 @@ export default () => { describe('Integration Tests', function() {
             // Generate keys
             const oldInitiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new DummyTask()])
                 .asInitiator();
             const oldResponder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .initiatorInfo(oldInitiator.permanentKeyBytes, oldInitiator.authTokenBytes)
                 .usingTasks([new DummyTask()])
@@ -234,12 +240,14 @@ export default () => { describe('Integration Tests', function() {
             // Use trusted keys to connect
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(oldInitiator.keyStore)
                 .withTrustedPeerKey(responderPublicKey)
                 .usingTasks([new DummyTask()])
                 .asInitiator();
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(oldResponder.keyStore)
                 .withTrustedPeerKey(initiatorPublicKey)
                 .usingTasks([new DummyTask()])
@@ -259,6 +267,7 @@ export default () => { describe('Integration Tests', function() {
             console.info('===> TEST NAME:', spec.getFullName());
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new DummyTask()])
                 .withServerKey(Config.SALTYRTC_SERVER_PUBLIC_KEY)
@@ -272,6 +281,7 @@ export default () => { describe('Integration Tests', function() {
             console.info('===> TEST NAME:', spec.getFullName());
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new DummyTask()])
                 .withServerKey('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
@@ -290,6 +300,7 @@ export default () => { describe('Integration Tests', function() {
             console.info('===> TEST NAME:', spec.getFullName());
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new DummyTask()])
                 .withServerKey(Config.SALTYRTC_SERVER_PUBLIC_KEY)
@@ -309,6 +320,7 @@ export default () => { describe('Integration Tests', function() {
                         port: Config.SALTYRTC_PORT,
                     };
                 })
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new DummyTask()])
                 .withServerKey(Config.SALTYRTC_SERVER_PUBLIC_KEY)
@@ -323,6 +335,7 @@ export default () => { describe('Integration Tests', function() {
             console.info('===> TEST NAME:', spec.getFullName());
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new DummyTask()])
                 .withServerKey('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
@@ -342,6 +355,7 @@ export default () => { describe('Integration Tests', function() {
             console.info('===> TEST NAME:', spec.getFullName());
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new DummyTask()])
                 .withServerKey(Config.SALTYRTC_SERVER_PUBLIC_KEY)
@@ -403,6 +417,7 @@ export default () => { describe('Integration Tests', function() {
                     for (let i = 0x02; i <= 0xff; i++) {
                         const r = new SaltyRTCBuilder()
                             .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                            .withLoggingLevel('warn')
                             .withKeyStore(new KeyStore())
                             .usingTasks([new DummyTask()])
                             .initiatorInfo(this.initiator.permanentKeyBytes, this.initiator.authTokenBytes)
@@ -430,6 +445,7 @@ export default () => { describe('Integration Tests', function() {
                 console.debug('====== Connecting real responder ======');
                 const responder = new SaltyRTCBuilder()
                     .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                    .withLoggingLevel('warn')
                     .withKeyStore(new KeyStore())
                     .usingTasks([new DummyTask()])
                     .initiatorInfo(this.initiator.permanentKeyBytes, this.initiator.authTokenBytes)
@@ -453,11 +469,13 @@ export default () => { describe('Integration Tests', function() {
             // Create peers
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .usingTasks([new PingPongTask()])
                 .asInitiator();
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
+                .withLoggingLevel('warn')
                 .withKeyStore(new KeyStore())
                 .initiatorInfo(initiator.permanentKeyBytes, initiator.authTokenBytes)
                 .usingTasks([new PingPongTask()])

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -18,6 +18,8 @@ import { sleep } from './utils';
 
 export default () => { describe('Integration Tests', function() {
 
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+
     beforeEach(() => {
         this.initiator = new SaltyRTCBuilder()
             .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -16,8 +16,6 @@ import { Config } from './config';
 import { DummyTask, PingPongTask } from './testtasks';
 import { sleep } from './utils';
 
-let spec: any;
-
 export default () => { describe('Integration Tests', function() {
 
     beforeEach(() => {
@@ -48,13 +46,12 @@ export default () => { describe('Integration Tests', function() {
                 a.connect();
                 b.connect();
             });
-        }
+        };
     });
 
     describe('SaltyRTC', () => {
 
-        spec = it('connect (initiator first)', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('connect (initiator first)', async () => {
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
             this.initiator.connect();
@@ -67,11 +64,9 @@ export default () => { describe('Integration Tests', function() {
             await sleep(1000);
             expect(this.initiator.state).toBe('task');
             expect(this.responder.state).toBe('task');
-            done();
         });
 
-        spec = it('connect (responder first)', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('connect (responder first)', async () => {
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
             this.responder.connect();
@@ -84,11 +79,9 @@ export default () => { describe('Integration Tests', function() {
             await sleep(1000);
             expect(this.initiator.state).toBe('task');
             expect(this.responder.state).toBe('task');
-            done();
         });
 
-        spec = it('connect speed', (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('connect speed', (done: any) => {
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
             let t1: Date;
@@ -111,8 +104,7 @@ export default () => { describe('Integration Tests', function() {
             this.responder.connect();
         });
 
-        spec = it('disconnect before peer handshake', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('disconnect before peer handshake', async (done: any) => {
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
             this.initiator.connect();
@@ -127,8 +119,7 @@ export default () => { describe('Integration Tests', function() {
             this.initiator.disconnect();
         });
 
-        spec = it('disconnect after peer handshake', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('disconnect after peer handshake', async (done: any) => {
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
             await this.connectBoth(this.initiator, this.responder);
@@ -140,8 +131,7 @@ export default () => { describe('Integration Tests', function() {
             this.initiator.disconnect();
         });
 
-        spec = it('new-responder event (responder first)', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('new-responder event (responder first)', async (done: any) => {
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
 
@@ -185,8 +175,7 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('new-responder event (initiator first)', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('new-responder event (initiator first)', async (done: any) => {
             expect(this.initiator.state).toEqual('new');
             expect(this.responder.state).toEqual('new');
 
@@ -208,18 +197,15 @@ export default () => { describe('Integration Tests', function() {
             done();
         });
 
-        spec = it('getting peer permanent key', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('getting peer permanent key', async () => {
             await this.connectBoth(this.initiator, this.responder);
             expect(this.initiator.peerPermanentKeyBytes).toEqual(this.responder.permanentKeyBytes);
             expect(this.responder.peerPermanentKeyBytes).toEqual(this.initiator.permanentKeyBytes);
             expect(this.initiator.peerPermanentKeyHex).toEqual(this.responder.permanentKeyHex);
             expect(this.responder.peerPermanentKeyHex).toEqual(this.initiator.permanentKeyHex);
-            done();
         });
 
-        spec = it('using trusted keys to connect', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('using trusted keys to connect', async () => {
             // Generate keys
             const oldInitiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
@@ -260,11 +246,9 @@ export default () => { describe('Integration Tests', function() {
 
             expect(initiator.state).toEqual('task');
             expect(responder.state).toEqual('task');
-            done();
         });
 
-        spec = it('validate server auth success (initiator)', (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('validate server auth success (initiator)', (done: any) => {
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
                 .withLoggingLevel('warn')
@@ -277,8 +261,7 @@ export default () => { describe('Integration Tests', function() {
             initiator.once('state-change:peer-handshake', done);
         });
 
-        spec = it('validate server auth validation fail (initiator)', (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('validate server auth validation fail (initiator)', (done: any) => {
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
                 .withLoggingLevel('warn')
@@ -296,8 +279,7 @@ export default () => { describe('Integration Tests', function() {
             });
         });
 
-        spec = it('validate server auth success (responder)', (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('validate server auth success (responder)', (done: any) => {
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
                 .withLoggingLevel('warn')
@@ -311,8 +293,7 @@ export default () => { describe('Integration Tests', function() {
             responder.once('state-change:peer-handshake', done);
         });
 
-        spec = it('connect dynamically using factory function', (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('connect dynamically using factory function', (done: any) => {
             const responder = new SaltyRTCBuilder()
                 .connectWith(() => {
                     return {
@@ -331,8 +312,7 @@ export default () => { describe('Integration Tests', function() {
             responder.once('state-change:peer-handshake', done);
         });
 
-        spec = it('validate server auth validation fail (responder)', (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('validate server auth validation fail (responder)', (done: any) => {
             const responder = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
                 .withLoggingLevel('warn')
@@ -351,8 +331,7 @@ export default () => { describe('Integration Tests', function() {
             });
         });
 
-        spec = it('send connection-closed event only once', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('send connection-closed event only once', async () => {
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
                 .withLoggingLevel('warn')
@@ -369,11 +348,9 @@ export default () => { describe('Integration Tests', function() {
             (initiator as any).signaling.closeWebsocket(3001);
             await sleep(100);
             expect(count).toEqual(1);
-            done();
         });
 
-        spec = it('can send application messages', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('can send application messages', async (done: any) => {
             await this.connectBoth(this.initiator, this.responder);
             expect(this.initiator.state).toEqual('task');
             expect(this.responder.state).toEqual('task');
@@ -405,8 +382,7 @@ export default () => { describe('Integration Tests', function() {
              * - Firefox: about:config -> network.websocket.max-connections
              * - Chrome: Not possible.
              */
-            spec = it('drops inactive responders when the path gets full', async (done: any) => {
-                console.info('===> TEST NAME:', spec.getFullName());
+            it('drops inactive responders when the path gets full', async (done: any) => {
                 this.initiator.connect();
                 await new Promise((resolve) => this.initiator.once('state-change:peer-handshake', resolve));
 
@@ -464,8 +440,7 @@ export default () => { describe('Integration Tests', function() {
     });
 
     describe('Tasks', () => {
-        spec = it('can send a ping pong task message', async (done: any) => {
-            console.info('===> TEST NAME:', spec.getFullName());
+        it('can send a ping pong task message', async () => {
             // Create peers
             const initiator = new SaltyRTCBuilder()
                 .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT)
@@ -513,7 +488,6 @@ export default () => { describe('Integration Tests', function() {
             await sleep(300);
             expect(initiator.state).toEqual('closed');
             expect(responder.state).toEqual('closed');
-            done();
         })
     });
 

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,5 +1,39 @@
 import '../node_modules/babel-es6-polyfill/browser-polyfill';
 
+// Apply log groups to Jasmine tests
+type Callback = (...args: any) => any;
+// @ts-ignore
+const jasmineIt = window.it;
+// @ts-ignore
+window.it = (description: string, callback: Callback, ...args) => {
+    const handler = (invoker: () => any) => {
+        console.group(spec.getFullName());
+        let result: any;
+        try {
+            result = invoker();
+        } catch (error) {
+            console.groupEnd();
+            throw error;
+        }
+        if (result instanceof Promise) {
+            result
+                .then(() => console.groupEnd())
+                .catch(() => console.groupEnd());
+        } else {
+            console.groupEnd();
+        }
+        return result;
+    };
+    let wrapper: Callback;
+    if (callback.length > 0) {
+        wrapper = (done: any) => handler(() => callback(done));
+    } else {
+        wrapper = () => handler(() => callback());
+    }
+    const spec = jasmineIt(description, wrapper, ...args);
+    return spec;
+};
+
 import test_client from './client.spec';
 import test_cookie from './cookie.spec';
 import test_csn from './csn.spec';
@@ -9,9 +43,6 @@ import test_integration from './integration.spec';
 import test_keystore from './keystore.spec';
 import test_nonce from './nonce.spec';
 import test_utils from './utils.spec';
-
-let counter = 1;
-beforeEach(() => console.info('------ TEST', counter++, 'BEGIN ------'));
 
 test_client();
 test_cookie();


### PR DESCRIPTION
With this PR we handle `new-initiator` and `new-responder` after a peer handshake properly (somewhat). Resolves #114.

An initiator now simply drops new responders when it has already completed the handshake with another responder.

A responder now closes the connection when a new initiator connects after it has already completed a handshake with a previous initiator.

Note that this deviates from the intention of the specification to allow for more than one connection towards a responder over the same WebSocket connection. But resolving this would be far from trivial.

---

Also makes use of console logging groups and thereby significantly improves readability. What the heck, we found a use case! :tada: 