### PR TITLE
Prevent client reuse

### DIFF
--- a/src/signaling/common.ts
+++ b/src/signaling/common.ts
@@ -54,6 +54,7 @@ export abstract class Signaling implements saltyrtc.Signaling {
     // Connection state
     protected state: saltyrtc.SignalingState = 'new';
     public handoverState = new HandoverState();
+    private neverConnected: boolean = true;
 
     // Main class
     protected client: saltyrtc.SaltyRTC;
@@ -167,6 +168,10 @@ export abstract class Signaling implements saltyrtc.Signaling {
      * Open a connection to the signaling server and do the handshake.
      */
     public connect(): void {
+        if (this.neverConnected !== true) {
+            throw new ConnectionError('Signaling instance cannot be reused. Please create a new client instance.');
+        }
+        this.neverConnected = false;
         this.resetConnection();
         this.initWebsocket();
     }

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -5,6 +5,7 @@
 import * as nacl from 'tweetnacl';
 
 import { SaltyRTCBuilder } from '../src/client';
+import { ConnectionError } from '../src/exceptions';
 import { Box, KeyStore } from '../src/keystore';
 import { u8aToHex } from '../src/utils';
 import { DummyTask } from './testtasks';
@@ -269,6 +270,23 @@ export default () => { describe('client', function() {
                 expect(counter).toEqual(5);
             });
 
+        });
+
+        describe('client', function() {
+            it('cannot be reused', () => {
+                const salty = new SaltyRTCBuilder()
+                    .connectTo('localhost')
+                    .withKeyStore(new KeyStore())
+                    .usingTasks([new DummyTask()])
+                    .asInitiator();
+                // First connection should be fine
+                expect(() => salty.connect()).not.toThrowError();
+                // Second connection attempt should throw an error
+                expect(() => salty.connect())
+                    .toThrow(new ConnectionError(
+                        'Signaling instance cannot be reused. Please create a new client instance.'
+                    ));
+            });
         });
 
         describe('application messages', function() {


### PR DESCRIPTION
Reusing client instances is not supported and probably will never be
supported. Instead, a new client instance should be created for every
connection attempt.

Fixes #119.